### PR TITLE
New XCP kernel patch to support UEFI 64bit EFI-FB

### DIFF
--- a/SOURCES/xen_dom0_64bit-efi.patch
+++ b/SOURCES/xen_dom0_64bit-efi.patch
@@ -1,0 +1,44 @@
+
+Patch by Andrew Lindh <andrew@netplex.net>
+Patch code copied from Linux Kernel 5.17
+Code tested on NUC 11 UEFI 64 bit EFI-FB and Supermicro UEFI 32 bit EFI-FB
+
+--- a/include/xen/interface/xen.h	2019-01-31 07:14:42.000000000 +0000
++++ b/include/xen/interface/xen.h	2022-04-22 17:41:38.053055993 +0000
+@@ -737,6 +722,9 @@
+ 			uint32_t gbl_caps;
+ 			/* Mode attributes (offset 0x0, VESA command 0x4f01). */
+ 			uint16_t mode_attrs;
++			uint16_t pad;
++			/* high 32 bits of lfb_base */
++			uint32_t ext_lfb_base;
+ 		} vesa_lfb;
+ 	} u;
+ };
+--- a/arch/x86/xen/vga.c	2019-01-31 07:14:42.000000000 +0000
++++ b/arch/x86/xen/vga.c	2022-04-22 17:41:22.260930826 +0000
+@@ -57,16 +57,20 @@
+ 		screen_info->rsvd_size = info->u.vesa_lfb.rsvd_size;
+ 		screen_info->rsvd_pos = info->u.vesa_lfb.rsvd_pos;
+ 
++		if (size >= offsetof(struct dom0_vga_console_info,
++				     u.vesa_lfb.ext_lfb_base)
++		    + sizeof(info->u.vesa_lfb.ext_lfb_base)
++		    && info->u.vesa_lfb.ext_lfb_base) {
++			screen_info->ext_lfb_base = info->u.vesa_lfb.ext_lfb_base;
++			screen_info->capabilities |= VIDEO_CAPABILITY_64BIT_BASE;
++		}
++
+ 		if (info->video_type == XEN_VGATYPE_EFI_LFB) {
+ 			screen_info->orig_video_isVGA = VIDEO_TYPE_EFI;
+ 			break;
+ 		}
+ 
+ 		if (size >= offsetof(struct dom0_vga_console_info,
+-				     u.vesa_lfb.gbl_caps)
+-		    + sizeof(info->u.vesa_lfb.gbl_caps))
+-			screen_info->capabilities = info->u.vesa_lfb.gbl_caps;
+-		if (size >= offsetof(struct dom0_vga_console_info,
+ 				     u.vesa_lfb.mode_attrs)
+ 		    + sizeof(info->u.vesa_lfb.mode_attrs))
+ 			screen_info->vesa_attributes = info->u.vesa_lfb.mode_attrs;

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -437,6 +437,7 @@ Patch378: 0001-x86-timer-Don-t-skip-PIT-setup-when-APIC-is-disabled.patch
 Patch379: xsa392-linux-1.patch
 Patch380: xsa392-linux-2.patch
 Patch381: abi-version.patch
+Patch381: xen_dom0_64bit-efi.patch
 
 Provides: gitsha(ssh://git@code.citrite.net/XSU/linux-stable.git) = dffbba4348e9686d6bf42d54eb0f2cd1c4fb3520
 Provides: gitsha(ssh://git@code.citrite.net/XS/linux.pg.git) = 36ae6b3fc7679d819f05402b14b2fb74a31507b4


### PR DESCRIPTION
New XCP kernel patch to support UEFI 64bit EFI-FB.
Code from Linux kernel 5.17
Tested on NUC 11 UEFI 64bit EFI-FB and Supermicro UEFI 32bit EFI-FB.

