### PR TITLE
perf: Add a stable patch to fix perf dynamic tracepoints

### DIFF
--- a/SOURCES/0001-perf-probe-Fix-getting-the-kernel-map.patch
+++ b/SOURCES/0001-perf-probe-Fix-getting-the-kernel-map.patch
@@ -1,0 +1,52 @@
+From 339937828e074df78788d0c1de87027a0820b794 Mon Sep 17 00:00:00 2001
+From: Adrian Hunter <adrian.hunter@intel.com>
+Date: Mon, 4 Mar 2019 15:13:21 +0200
+Subject: [PATCH] perf probe: Fix getting the kernel map
+
+commit eaeffeb9838a7c0dec981d258666bfcc0fa6a947 upstream.
+
+Since commit 4d99e4136580 ("perf machine: Workaround missing maps for
+x86 PTI entry trampolines"), perf tools has been creating more than one
+kernel map, however 'perf probe' assumed there could be only one.
+
+Fix by using machine__kernel_map() to get the main kernel map.
+
+Signed-off-by: Adrian Hunter <adrian.hunter@intel.com>
+Tested-by: Joseph Qi <joseph.qi@linux.alibaba.com>
+Acked-by: Masami Hiramatsu <mhiramat@kernel.org>
+Cc: Alexander Shishkin <alexander.shishkin@linux.intel.com>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Cc: Jiufei Xue <jiufei.xue@linux.alibaba.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: stable@vger.kernel.org
+Cc: Xu Yu <xuyu@linux.alibaba.com>
+Fixes: 4d99e4136580 ("perf machine: Workaround missing maps for x86 PTI entry trampolines")
+Fixes: d83212d5dd67 ("kallsyms, x86: Export addresses of PTI entry trampolines")
+Link: http://lkml.kernel.org/r/2ed432de-e904-85d2-5c36-5897ddc5b23b@intel.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ tools/perf/util/probe-event.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tools/perf/util/probe-event.c b/tools/perf/util/probe-event.c
+index f119eb628dbb..a22e1f538aea 100644
+--- a/tools/perf/util/probe-event.c
++++ b/tools/perf/util/probe-event.c
+@@ -157,8 +157,10 @@ static struct map *kernel_get_module_map(const char *module)
+ 	if (module && strchr(module, '/'))
+ 		return dso__new_map(module);
+ 
+-	if (!module)
+-		module = "kernel";
++	if (!module) {
++		pos = machine__kernel_map(host_machine);
++		return map__get(pos);
++	}
+ 
+ 	for (pos = maps__first(maps); pos; pos = map__next(pos)) {
+ 		/* short_name is "[module]" */
+-- 
+2.49.0
+

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -37,7 +37,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -690,6 +690,7 @@ Source5: prepare-build
 # XCP-ng patches
 Patch1000: ceph.patch
 Patch1001: tg3-v4.19.315.patch
+Patch1002: 0001-perf-probe-Fix-getting-the-kernel-map.patch
 
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
@@ -1044,6 +1045,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Sun Apr 06 2025 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 4.19.19-8.0.38.2
+- Backport perf dynamic tracepoints fixes
+
 * Fri Mar 28 2025 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.19.19-8.0.38.1
 - Sync with 4.19.19-8.0.38
 - *** Upstream changelog ***


### PR DESCRIPTION
This patch fixes the command "perf probe" that allows you to set dynamic tracepoints wherever you want (line granularity). It's very useful to debug kernel problems.

This patch comes from v4.19.32 and only changes perf tool (no kernel change).