### PR TITLE
Backport ACPI NULL dereference fix

### DIFF
--- a/SOURCES/0001-ACPI-processor-idle-Check-acpi_bus_get_device-return.patch
+++ b/SOURCES/0001-ACPI-processor-idle-Check-acpi_bus_get_device-return.patch
@@ -1,0 +1,34 @@
+From fb3b2d198a1701a7d2806c198963f6cbd3b95e43 Mon Sep 17 00:00:00 2001
+Message-ID: <fb3b2d198a1701a7d2806c198963f6cbd3b95e43.1750668495.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Mon, 23 Jun 2025 10:48:10 +0200
+Subject: [PATCH] ACPI: processor: idle: Check acpi_bus_get_device return value
+
+From: Li Zhong <floridsleeves@gmail.com>
+
+Fix a potential NULL pointer dereferences if acpi_bus_get_device happens to fail.
+
+Backported-from: 2437513a814b3 "ACPI: processor: idle: Check acpi_fetch_acpi_dev() return value"
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+ drivers/acpi/processor_idle.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/acpi/processor_idle.c b/drivers/acpi/processor_idle.c
+index abb559cd28d7..e0bfe3450eb6 100644
+--- a/drivers/acpi/processor_idle.c
++++ b/drivers/acpi/processor_idle.c
+@@ -1190,7 +1190,9 @@ static int acpi_processor_get_lpi_info(struct acpi_processor *pr)
+ 
+ 	status = acpi_get_parent(handle, &pr_ahandle);
+ 	while (ACPI_SUCCESS(status)) {
+-		acpi_bus_get_device(pr_ahandle, &d);
++		if (acpi_bus_get_device(pr_ahandle, &d))
++			break;
++
+ 		handle = pr_ahandle;
+ 
+ 		if (strcmp(acpi_device_hid(d), ACPI_PROCESSOR_CONTAINER_HID))
+-- 
+2.50.0
+

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -37,7 +37,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -691,6 +691,7 @@ Source5: prepare-build
 Patch1000: ceph.patch
 Patch1001: tg3-v4.19.315.patch
 Patch1002: 0001-perf-probe-Fix-getting-the-kernel-map.patch
+Patch1003: 0001-ACPI-processor-idle-Check-acpi_bus_get_device-return.patch
 
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
@@ -1045,6 +1046,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Jun 23 2025 Teddy Astie <teddy.astie@vates.tech> - 4.19.19-8.0.38.3
+- Backport ACPI NULL dereference fix (Minisforum MS-A2 - Ryzen 9 7945HX kernel panic)
+
 * Sun Apr 06 2025 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 4.19.19-8.0.38.2
 - Backport perf dynamic tracepoints fixes
 


### PR DESCRIPTION
Fix a crash with Minisforum MS-A2 (Ryzen 9 7945HX).
Forum post: https://xcp-ng.org/forum/topic/10972/xcp-ng-8.3-lts-install-on-minisforum-ms-a2-7945hx