### PR TITLE
Add fix for CVE-2026-31431 from Gentoo

### DIFF
--- a/SOURCES/0001-crypto-disable-authencesn-module-for-CVE-2026-31431.patch
+++ b/SOURCES/0001-crypto-disable-authencesn-module-for-CVE-2026-31431.patch
@@ -1,0 +1,39 @@
+From f9d6a311a79c33235ce321a523e57bcd001726ab Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 30 Apr 2026 03:14:26 +0100
+Subject: [PATCH] crypto: disable authencesn module for CVE-2026-31431
+
+The fix in 6.18 and beyond uses memcpy_sglist which got added in
+131bdceca1f0a2d9381270dc40f898458e5e184b, but then they change it in
+0f8d42bf128d349ad490e87d5574d211245e40f1 and
+4dffc9bbffb9ccfcda730d899c97c553599e7ca8, then drop one of the earlier
+changes in 20d868a77f11ba050fe96e7b8efb8ec3b6f2737f.
+
+It's easier to disable the authencesn module as a mitigation for now
+until older kernels get fixed upstream. It should only make IPSec slower
+in some cases to have it off.
+
+Bug: https://bugs.gentoo.org/973385
+Signed-off-by: Sam James <sam@gentoo.org>
+
+Manually backported by deleting the corresponding .o entry from the
+Makefile.
+
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+---
+ crypto/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/Makefile b/crypto/Makefile
+index f6a234d08882..ba7f87e049a7 100644
+--- a/crypto/Makefile
++++ b/crypto/Makefile
+@@ -123,7 +123,7 @@ obj-$(CONFIG_CRYPTO_MICHAEL_MIC) += michael_mic.o
+ obj-$(CONFIG_CRYPTO_CRC32C) += crc32c_generic.o
+ obj-$(CONFIG_CRYPTO_CRC32) += crc32_generic.o
+ obj-$(CONFIG_CRYPTO_CRCT10DIF) += crct10dif_common.o crct10dif_generic.o
+-obj-$(CONFIG_CRYPTO_AUTHENC) += authenc.o authencesn.o
++obj-$(CONFIG_CRYPTO_AUTHENC) += authenc.o
+ obj-$(CONFIG_CRYPTO_LZO) += lzo.o
+ obj-$(CONFIG_CRYPTO_LZ4) += lz4.o
+ obj-$(CONFIG_CRYPTO_LZ4HC) += lz4hc.o

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -735,6 +735,7 @@ Patch1003: 0001-ACPI-processor-idle-Check-acpi_bus_get_device-return.patch
 Patch1004: 0001-scsi-target-Fix-XCOPY-NAA-identifier-lookup.patch
 Patch1005: 0001-ext4-fix-off-by-one-error-in-do_split.patch
 Patch1006: 0001-SUNRPC-Restore-missing-call-to-cancel_work_sync.patch
+Patch1007: 0001-crypto-disable-authencesn-module-for-CVE-2026-31431.patch
 
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
@@ -1089,6 +1090,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Fri May 01 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.19.19-8.0.46.2
+- Disable authencesn module for CVE-2026-31431
+
 * Fri Mar 27 2026 Thierry Escande <thierry.escande@vates.tech> - 4.19.19-8.0.46.1
 - Sync with 4.19.19-8.0.46
 - SUNRPC: Restore call to cancel_work_sync()


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3243

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Fixes CVE-2026-31431 (CopyFail).

Patch taken from https://www.openwall.com/lists/oss-security/2026/04/30/10

It disables the specific vulnerable `authencesn` module. Unlike the modprobe config mitigation, it doesn't impact the other uses of `algif_aead`.

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

Tuesday update?

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Fixes CVE-2026-31431 (CopyFail).

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

This update disables IPSec ESN support. Encrypted GPN performance may be reduced in some cases.

#### Documentation update needed

- [ ] Yes
- [ ] No
- [x] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

A VSA might be needed?

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Local install and starting of VMs.

Fix verified using POC at https://gist.github.com/dinhngtu/5ce8203e7ee73297dbc97318e3108136 (originally https://github.com/slaptat/copyFail30/blob/344b25987230b944d999528479b3d98c1729afdc/copyFail30.py)

**The POC may corrupt the Su binary, run it on a local setuid copy of Su instead. My version uses `./su` and so shouldn't touch the main binary.**

Encrypted GPN testing done by Sébastien Rodot (couldn't find his GitHub)

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Test if encrypted GPN functions properly

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Main tests

#### What tests have been or will be added to CI for this change? If none, explain why.

N/A

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->