### PR TITLE
Overcome rpm limit for scriptlet size

### DIFF
--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -36,13 +36,13 @@
 
 # Be strict when applying patches
 %if 0%{?xenserver} < 9
-%global __patch /usr/bin/patch --fuzz=0
+%global __patch /bin/patch -F0
 %endif
 
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.4%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -1091,6 +1091,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Wed May 13 2026 Yann Dirson <yann.dirson@vates.tech> - 4.19.19-8.0.46.4
+- Use short flag and short path to patch command to avoid overflowing a rpm limitation
+
 * Tue May 12 2026 Thierry Escande <thierry.escande@vates.tech> - 4.19.19-8.0.46.3
 - Backport for CVE-2026-43284 (DirtyFrag, XFRM-ESP path or CopyFail2) from linux-5.10.y
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

N/A

#### Related changes (optional)

N/A

#### Context & Motivation

XS 8.4 kernels have started adding `--fuzz=0` to `patch` commands, which results in a big size bump of the buffer used to prepare patch commands for the `%prep` scriptlet.
Longer build paths in build-env container, and larger number of patches cause that buffer to silently hits its limits (`rpmbuild` bug that was fixed in later versions), and (luckily) produce a buggy script trying to load a patch from a truncated path.

Using the short form of the option buys us some time to consider a longer-term solution (like using a Git tree instead of a list of patches, or patching `rpm`).  Note that relying on this only is not sufficient, but we can also use `/bin/patch` instead of `/usr/bin/patch` to spare more text.

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

---

### Release Notes and Documentation

#### Explain the change to users

N/A

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

EXPLANATIONS

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Package "prep" step in container:
```
$ xcp-ng-dev container build 8.3 --rpmbuild-stage=p
...
+ /bin/patch -F0 -p1 -s
+ /usr/bin/cat /home/builder/rpmbuild/SOURCES/0001-SUNRPC-Restore-missing-call-to-cancel_work_sync.patch
+ /usr/bin/cat /home/builder/rpmbuild/SOURCES/0001-crypto-disable-authencesn-module-for-CVE-2026-31431.patch
+ /bin/patch -F0 -p1 -s
+ exit 0
```

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

N/A

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

None.

#### What tests have been or will be added to CI for this change? If none, explain why.

None, this is a build-time change only.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
