### PR TITLE
Add fix for CVE-2026-43284 (DirtyFrag XFRM-ESP path and CopyFail2) and CVE-2026-31431 (CopyFail)

### DIFF
--- a/SOURCES/0001-crypto-skcipher-Introduce-crypto_sync_skcipher.patch
+++ b/SOURCES/0001-crypto-skcipher-Introduce-crypto_sync_skcipher.patch
@@ -1,0 +1,220 @@
+From 183836a754b8d109e54c011f41dea823112e4220 Mon Sep 17 00:00:00 2001
+From: Kees Cook <keescook@chromium.org>
+Date: Tue, 18 Sep 2018 19:10:38 -0700
+Subject: [PATCH] crypto: skcipher - Introduce crypto_sync_skcipher
+
+In preparation for removal of VLAs due to skcipher requests on the stack
+via SKCIPHER_REQUEST_ON_STACK() usage, this introduces the infrastructure
+for the "sync skcipher" tfm, which is for handling the on-stack cases of
+skcipher, which are always non-ASYNC and have a known limited request
+size.
+
+The crypto API additions:
+
+	struct crypto_sync_skcipher (wrapper for struct crypto_skcipher)
+	crypto_alloc_sync_skcipher()
+	crypto_free_sync_skcipher()
+	crypto_sync_skcipher_setkey()
+	crypto_sync_skcipher_get_flags()
+	crypto_sync_skcipher_set_flags()
+	crypto_sync_skcipher_clear_flags()
+	crypto_sync_skcipher_blocksize()
+	crypto_sync_skcipher_ivsize()
+	crypto_sync_skcipher_reqtfm()
+	skcipher_request_set_sync_tfm()
+	SYNC_SKCIPHER_REQUEST_ON_STACK() (with tfm type check)
+
+Signed-off-by: Kees Cook <keescook@chromium.org>
+Reviewed-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+(cherry picked from commit b350bee5ea0f4db75d4c6191a2e95db16f40c278)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/skcipher.c         | 24 +++++++++++++
+ include/crypto/skcipher.h | 75 +++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 99 insertions(+)
+
+diff --git a/crypto/skcipher.c b/crypto/skcipher.c
+index 0bd8c6caa498..4caab81d2d02 100644
+--- a/crypto/skcipher.c
++++ b/crypto/skcipher.c
+@@ -949,6 +949,30 @@ struct crypto_skcipher *crypto_alloc_skcipher(const char *alg_name,
+ }
+ EXPORT_SYMBOL_GPL(crypto_alloc_skcipher);
+ 
++struct crypto_sync_skcipher *crypto_alloc_sync_skcipher(
++				const char *alg_name, u32 type, u32 mask)
++{
++	struct crypto_skcipher *tfm;
++
++	/* Only sync algorithms allowed. */
++	mask |= CRYPTO_ALG_ASYNC;
++
++	tfm = crypto_alloc_tfm(alg_name, &crypto_skcipher_type2, type, mask);
++
++	/*
++	 * Make sure we do not allocate something that might get used with
++	 * an on-stack request: check the request size.
++	 */
++	if (!IS_ERR(tfm) && WARN_ON(crypto_skcipher_reqsize(tfm) >
++				    MAX_SYNC_SKCIPHER_REQSIZE)) {
++		crypto_free_skcipher(tfm);
++		return ERR_PTR(-EINVAL);
++	}
++
++	return (struct crypto_sync_skcipher *)tfm;
++}
++EXPORT_SYMBOL_GPL(crypto_alloc_sync_skcipher);
++
+ int crypto_has_skcipher2(const char *alg_name, u32 type, u32 mask)
+ {
+ 	return crypto_type_has_alg(alg_name, &crypto_skcipher_type2,
+diff --git a/include/crypto/skcipher.h b/include/crypto/skcipher.h
+index 2f327f090c3e..d00ce90dc7da 100644
+--- a/include/crypto/skcipher.h
++++ b/include/crypto/skcipher.h
+@@ -65,6 +65,10 @@ struct crypto_skcipher {
+ 	struct crypto_tfm base;
+ };
+ 
++struct crypto_sync_skcipher {
++	struct crypto_skcipher base;
++};
++
+ /**
+  * struct skcipher_alg - symmetric key cipher definition
+  * @min_keysize: Minimum key size supported by the transformation. This is the
+@@ -139,6 +143,19 @@ struct skcipher_alg {
+ 	struct crypto_alg base;
+ };
+ 
++#define MAX_SYNC_SKCIPHER_REQSIZE      384
++/*
++ * This performs a type-check against the "tfm" argument to make sure
++ * all users have the correct skcipher tfm for doing on-stack requests.
++ */
++#define SYNC_SKCIPHER_REQUEST_ON_STACK(name, tfm) \
++	char __##name##_desc[sizeof(struct skcipher_request) + \
++			     MAX_SYNC_SKCIPHER_REQSIZE + \
++			     (!(sizeof((struct crypto_sync_skcipher *)1 == \
++				       (typeof(tfm))1))) \
++			    ] CRYPTO_MINALIGN_ATTR; \
++	struct skcipher_request *name = (void *)__##name##_desc
++
+ #define SKCIPHER_REQUEST_ON_STACK(name, tfm) \
+ 	char __##name##_desc[sizeof(struct skcipher_request) + \
+ 		crypto_skcipher_reqsize(tfm)] CRYPTO_MINALIGN_ATTR; \
+@@ -197,6 +214,9 @@ static inline struct crypto_skcipher *__crypto_skcipher_cast(
+ struct crypto_skcipher *crypto_alloc_skcipher(const char *alg_name,
+ 					      u32 type, u32 mask);
+ 
++struct crypto_sync_skcipher *crypto_alloc_sync_skcipher(const char *alg_name,
++					      u32 type, u32 mask);
++
+ static inline struct crypto_tfm *crypto_skcipher_tfm(
+ 	struct crypto_skcipher *tfm)
+ {
+@@ -212,6 +232,11 @@ static inline void crypto_free_skcipher(struct crypto_skcipher *tfm)
+ 	crypto_destroy_tfm(tfm, crypto_skcipher_tfm(tfm));
+ }
+ 
++static inline void crypto_free_sync_skcipher(struct crypto_sync_skcipher *tfm)
++{
++	crypto_free_skcipher(&tfm->base);
++}
++
+ /**
+  * crypto_has_skcipher() - Search for the availability of an skcipher.
+  * @alg_name: is the cra_name / name or cra_driver_name / driver name of the
+@@ -280,6 +305,12 @@ static inline unsigned int crypto_skcipher_ivsize(struct crypto_skcipher *tfm)
+ 	return tfm->ivsize;
+ }
+ 
++static inline unsigned int crypto_sync_skcipher_ivsize(
++	struct crypto_sync_skcipher *tfm)
++{
++	return crypto_skcipher_ivsize(&tfm->base);
++}
++
+ static inline unsigned int crypto_skcipher_alg_chunksize(
+ 	struct skcipher_alg *alg)
+ {
+@@ -356,6 +387,12 @@ static inline unsigned int crypto_skcipher_blocksize(
+ 	return crypto_tfm_alg_blocksize(crypto_skcipher_tfm(tfm));
+ }
+ 
++static inline unsigned int crypto_sync_skcipher_blocksize(
++	struct crypto_sync_skcipher *tfm)
++{
++	return crypto_skcipher_blocksize(&tfm->base);
++}
++
+ static inline unsigned int crypto_skcipher_alignmask(
+ 	struct crypto_skcipher *tfm)
+ {
+@@ -379,6 +416,24 @@ static inline void crypto_skcipher_clear_flags(struct crypto_skcipher *tfm,
+ 	crypto_tfm_clear_flags(crypto_skcipher_tfm(tfm), flags);
+ }
+ 
++static inline u32 crypto_sync_skcipher_get_flags(
++	struct crypto_sync_skcipher *tfm)
++{
++	return crypto_skcipher_get_flags(&tfm->base);
++}
++
++static inline void crypto_sync_skcipher_set_flags(
++	struct crypto_sync_skcipher *tfm, u32 flags)
++{
++	crypto_skcipher_set_flags(&tfm->base, flags);
++}
++
++static inline void crypto_sync_skcipher_clear_flags(
++	struct crypto_sync_skcipher *tfm, u32 flags)
++{
++	crypto_skcipher_clear_flags(&tfm->base, flags);
++}
++
+ /**
+  * crypto_skcipher_setkey() - set key for cipher
+  * @tfm: cipher handle
+@@ -401,6 +456,12 @@ static inline int crypto_skcipher_setkey(struct crypto_skcipher *tfm,
+ 	return tfm->setkey(tfm, key, keylen);
+ }
+ 
++static inline int crypto_sync_skcipher_setkey(struct crypto_sync_skcipher *tfm,
++					 const u8 *key, unsigned int keylen)
++{
++	return crypto_skcipher_setkey(&tfm->base, key, keylen);
++}
++
+ static inline unsigned int crypto_skcipher_default_keysize(
+ 	struct crypto_skcipher *tfm)
+ {
+@@ -422,6 +483,14 @@ static inline struct crypto_skcipher *crypto_skcipher_reqtfm(
+ 	return __crypto_skcipher_cast(req->base.tfm);
+ }
+ 
++static inline struct crypto_sync_skcipher *crypto_sync_skcipher_reqtfm(
++	struct skcipher_request *req)
++{
++	struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(req);
++
++	return container_of(tfm, struct crypto_sync_skcipher, base);
++}
++
+ /**
+  * crypto_skcipher_encrypt() - encrypt plaintext
+  * @req: reference to the skcipher_request handle that holds all information
+@@ -500,6 +569,12 @@ static inline void skcipher_request_set_tfm(struct skcipher_request *req,
+ 	req->base.tfm = crypto_skcipher_tfm(tfm);
+ }
+ 
++static inline void skcipher_request_set_sync_tfm(struct skcipher_request *req,
++					    struct crypto_sync_skcipher *tfm)
++{
++	skcipher_request_set_tfm(req, &tfm->base);
++}
++
+ static inline struct skcipher_request *skcipher_request_cast(
+ 	struct crypto_async_request *req)
+ {

--- a/SOURCES/0002-crypto-null-Remove-VLA-usage-of-skcipher.patch
+++ b/SOURCES/0002-crypto-null-Remove-VLA-usage-of-skcipher.patch
@@ -1,0 +1,278 @@
+From 96bef4abd113fda1962597319a9b6e7ad8945e65 Mon Sep 17 00:00:00 2001
+From: Kees Cook <keescook@chromium.org>
+Date: Tue, 18 Sep 2018 19:10:51 -0700
+Subject: [PATCH] crypto: null - Remove VLA usage of skcipher
+
+In the quest to remove all stack VLA usage from the kernel[1], this
+replaces struct crypto_skcipher and SKCIPHER_REQUEST_ON_STACK() usage
+with struct crypto_sync_skcipher and SYNC_SKCIPHER_REQUEST_ON_STACK(),
+which uses a fixed stack size.
+
+[1] https://lkml.kernel.org/r/CA+55aFzCG-zNmZwX4A2FQpadafLfEzK6CC=qPXydAacU1RqZWA@mail.gmail.com
+
+Signed-off-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+(cherry picked from commit 8d605398425843c7ce3c0e9a0434d832d3bd54cc)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_aead.c             | 12 ++++++------
+ crypto/authenc.c                |  8 ++++----
+ crypto/authencesn.c             |  8 ++++----
+ crypto/crypto_null.c            | 11 +++++------
+ crypto/echainiv.c               |  4 ++--
+ crypto/gcm.c                    |  8 ++++----
+ crypto/seqiv.c                  |  4 ++--
+ include/crypto/internal/geniv.h |  2 +-
+ include/crypto/null.h           |  2 +-
+ 9 files changed, 29 insertions(+), 30 deletions(-)
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index c40a8c7ee8ae..eb100a04ce9f 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -42,7 +42,7 @@
+ 
+ struct aead_tfm {
+ 	struct crypto_aead *aead;
+-	struct crypto_skcipher *null_tfm;
++	struct crypto_sync_skcipher *null_tfm;
+ };
+ 
+ static inline bool aead_sufficient_data(struct sock *sk)
+@@ -75,13 +75,13 @@ static int aead_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
+ 	return af_alg_sendmsg(sock, msg, size, ivsize);
+ }
+ 
+-static int crypto_aead_copy_sgl(struct crypto_skcipher *null_tfm,
++static int crypto_aead_copy_sgl(struct crypto_sync_skcipher *null_tfm,
+ 				struct scatterlist *src,
+ 				struct scatterlist *dst, unsigned int len)
+ {
+-	SKCIPHER_REQUEST_ON_STACK(skreq, null_tfm);
++	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, null_tfm);
+ 
+-	skcipher_request_set_tfm(skreq, null_tfm);
++	skcipher_request_set_sync_tfm(skreq, null_tfm);
+ 	skcipher_request_set_callback(skreq, CRYPTO_TFM_REQ_MAY_BACKLOG,
+ 				      NULL, NULL);
+ 	skcipher_request_set_crypt(skreq, src, dst, len, NULL);
+@@ -99,7 +99,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct aead_tfm *aeadc = pask->private;
+ 	struct crypto_aead *tfm = aeadc->aead;
+-	struct crypto_skcipher *null_tfm = aeadc->null_tfm;
++	struct crypto_sync_skcipher *null_tfm = aeadc->null_tfm;
+ 	unsigned int i, as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct af_alg_tsgl *tsgl, *tmp;
+@@ -478,7 +478,7 @@ static void *aead_bind(const char *name, u32 type, u32 mask)
+ {
+ 	struct aead_tfm *tfm;
+ 	struct crypto_aead *aead;
+-	struct crypto_skcipher *null_tfm;
++	struct crypto_sync_skcipher *null_tfm;
+ 
+ 	tfm = kzalloc(sizeof(*tfm), GFP_KERNEL);
+ 	if (!tfm)
+diff --git a/crypto/authenc.c b/crypto/authenc.c
+index 3ee10fc25aff..4be293a4b5f0 100644
+--- a/crypto/authenc.c
++++ b/crypto/authenc.c
+@@ -33,7 +33,7 @@ struct authenc_instance_ctx {
+ struct crypto_authenc_ctx {
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_skcipher *null;
++	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_request_ctx {
+@@ -193,9 +193,9 @@ static int crypto_authenc_copy_assoc(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+ 	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(authenc);
+-	SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
++	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+ 
+-	skcipher_request_set_tfm(skreq, ctx->null);
++	skcipher_request_set_sync_tfm(skreq, ctx->null);
+ 	skcipher_request_set_callback(skreq, aead_request_flags(req),
+ 				      NULL, NULL);
+ 	skcipher_request_set_crypt(skreq, req->src, req->dst, req->assoclen,
+@@ -326,7 +326,7 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_skcipher *null;
++	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+index 4eff4be6bd12..4741fe89ba2c 100644
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -36,7 +36,7 @@ struct crypto_authenc_esn_ctx {
+ 	unsigned int reqoff;
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_skcipher *null;
++	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_esn_request_ctx {
+@@ -183,9 +183,9 @@ static int crypto_authenc_esn_copy(struct aead_request *req, unsigned int len)
+ {
+ 	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+ 	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(authenc_esn);
+-	SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
++	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+ 
+-	skcipher_request_set_tfm(skreq, ctx->null);
++	skcipher_request_set_sync_tfm(skreq, ctx->null);
+ 	skcipher_request_set_callback(skreq, aead_request_flags(req),
+ 				      NULL, NULL);
+ 	skcipher_request_set_crypt(skreq, req->src, req->dst, len, NULL);
+@@ -341,7 +341,7 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_skcipher *null;
++	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+diff --git a/crypto/crypto_null.c b/crypto/crypto_null.c
+index 0959b268966c..0bae59922a80 100644
+--- a/crypto/crypto_null.c
++++ b/crypto/crypto_null.c
+@@ -26,7 +26,7 @@
+ #include <linux/string.h>
+ 
+ static DEFINE_MUTEX(crypto_default_null_skcipher_lock);
+-static struct crypto_skcipher *crypto_default_null_skcipher;
++static struct crypto_sync_skcipher *crypto_default_null_skcipher;
+ static int crypto_default_null_skcipher_refcnt;
+ 
+ static int null_compress(struct crypto_tfm *tfm, const u8 *src,
+@@ -152,16 +152,15 @@ MODULE_ALIAS_CRYPTO("compress_null");
+ MODULE_ALIAS_CRYPTO("digest_null");
+ MODULE_ALIAS_CRYPTO("cipher_null");
+ 
+-struct crypto_skcipher *crypto_get_default_null_skcipher(void)
++struct crypto_sync_skcipher *crypto_get_default_null_skcipher(void)
+ {
+-	struct crypto_skcipher *tfm;
++	struct crypto_sync_skcipher *tfm;
+ 
+ 	mutex_lock(&crypto_default_null_skcipher_lock);
+ 	tfm = crypto_default_null_skcipher;
+ 
+ 	if (!tfm) {
+-		tfm = crypto_alloc_skcipher("ecb(cipher_null)",
+-					    0, CRYPTO_ALG_ASYNC);
++		tfm = crypto_alloc_sync_skcipher("ecb(cipher_null)", 0, 0);
+ 		if (IS_ERR(tfm))
+ 			goto unlock;
+ 
+@@ -181,7 +180,7 @@ void crypto_put_default_null_skcipher(void)
+ {
+ 	mutex_lock(&crypto_default_null_skcipher_lock);
+ 	if (!--crypto_default_null_skcipher_refcnt) {
+-		crypto_free_skcipher(crypto_default_null_skcipher);
++		crypto_free_sync_skcipher(crypto_default_null_skcipher);
+ 		crypto_default_null_skcipher = NULL;
+ 	}
+ 	mutex_unlock(&crypto_default_null_skcipher_lock);
+diff --git a/crypto/echainiv.c b/crypto/echainiv.c
+index 45819e6015bf..77e607fdbfb7 100644
+--- a/crypto/echainiv.c
++++ b/crypto/echainiv.c
+@@ -47,9 +47,9 @@ static int echainiv_encrypt(struct aead_request *req)
+ 	info = req->iv;
+ 
+ 	if (req->src != req->dst) {
+-		SKCIPHER_REQUEST_ON_STACK(nreq, ctx->sknull);
++		SYNC_SKCIPHER_REQUEST_ON_STACK(nreq, ctx->sknull);
+ 
+-		skcipher_request_set_tfm(nreq, ctx->sknull);
++		skcipher_request_set_sync_tfm(nreq, ctx->sknull);
+ 		skcipher_request_set_callback(nreq, req->base.flags,
+ 					      NULL, NULL);
+ 		skcipher_request_set_crypt(nreq, req->src, req->dst,
+diff --git a/crypto/gcm.c b/crypto/gcm.c
+index 0ad879e1f9b2..e438492db2ca 100644
+--- a/crypto/gcm.c
++++ b/crypto/gcm.c
+@@ -50,7 +50,7 @@ struct crypto_rfc4543_instance_ctx {
+ 
+ struct crypto_rfc4543_ctx {
+ 	struct crypto_aead *child;
+-	struct crypto_skcipher *null;
++	struct crypto_sync_skcipher *null;
+ 	u8 nonce[4];
+ };
+ 
+@@ -1067,9 +1067,9 @@ static int crypto_rfc4543_copy_src_to_dst(struct aead_request *req, bool enc)
+ 	unsigned int authsize = crypto_aead_authsize(aead);
+ 	unsigned int nbytes = req->assoclen + req->cryptlen -
+ 			      (enc ? 0 : authsize);
+-	SKCIPHER_REQUEST_ON_STACK(nreq, ctx->null);
++	SYNC_SKCIPHER_REQUEST_ON_STACK(nreq, ctx->null);
+ 
+-	skcipher_request_set_tfm(nreq, ctx->null);
++	skcipher_request_set_sync_tfm(nreq, ctx->null);
+ 	skcipher_request_set_callback(nreq, req->base.flags, NULL, NULL);
+ 	skcipher_request_set_crypt(nreq, req->src, req->dst, nbytes, NULL);
+ 
+@@ -1093,7 +1093,7 @@ static int crypto_rfc4543_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_aead_spawn *spawn = &ictx->aead;
+ 	struct crypto_rfc4543_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_aead *aead;
+-	struct crypto_skcipher *null;
++	struct crypto_sync_skcipher *null;
+ 	unsigned long align;
+ 	int err = 0;
+ 
+diff --git a/crypto/seqiv.c b/crypto/seqiv.c
+index 39dbf2f7e5f5..64a412be255e 100644
+--- a/crypto/seqiv.c
++++ b/crypto/seqiv.c
+@@ -73,9 +73,9 @@ static int seqiv_aead_encrypt(struct aead_request *req)
+ 	info = req->iv;
+ 
+ 	if (req->src != req->dst) {
+-		SKCIPHER_REQUEST_ON_STACK(nreq, ctx->sknull);
++		SYNC_SKCIPHER_REQUEST_ON_STACK(nreq, ctx->sknull);
+ 
+-		skcipher_request_set_tfm(nreq, ctx->sknull);
++		skcipher_request_set_sync_tfm(nreq, ctx->sknull);
+ 		skcipher_request_set_callback(nreq, req->base.flags,
+ 					      NULL, NULL);
+ 		skcipher_request_set_crypt(nreq, req->src, req->dst,
+diff --git a/include/crypto/internal/geniv.h b/include/crypto/internal/geniv.h
+index 2bcfb931bc5b..71be24cd59bd 100644
+--- a/include/crypto/internal/geniv.h
++++ b/include/crypto/internal/geniv.h
+@@ -20,7 +20,7 @@
+ struct aead_geniv_ctx {
+ 	spinlock_t lock;
+ 	struct crypto_aead *child;
+-	struct crypto_skcipher *sknull;
++	struct crypto_sync_skcipher *sknull;
+ 	u8 salt[] __attribute__ ((aligned(__alignof__(u32))));
+ };
+ 
+diff --git a/include/crypto/null.h b/include/crypto/null.h
+index 15aeef6e30ef..0ef577cc00e3 100644
+--- a/include/crypto/null.h
++++ b/include/crypto/null.h
+@@ -9,7 +9,7 @@
+ #define NULL_DIGEST_SIZE	0
+ #define NULL_IV_SIZE		0
+ 
+-struct crypto_skcipher *crypto_get_default_null_skcipher(void);
++struct crypto_sync_skcipher *crypto_get_default_null_skcipher(void);
+ void crypto_put_default_null_skcipher(void);
+ 
+ #endif

--- a/SOURCES/0003-kabi-crypto-null-Remove-VLA-usage-of-skcipher.patch
+++ b/SOURCES/0003-kabi-crypto-null-Remove-VLA-usage-of-skcipher.patch
@@ -1,0 +1,35 @@
+From d06506f7c8ba498532d2ac0cf3fd68d88e2e8739 Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Mon, 4 May 2026 14:26:23 +0200
+Subject: [PATCH] !kabi crypto: null - Remove VLA usage of skcipher
+
+Fixes: e45745e9a5e9 (\"crypto: null - Remove VLA usage of skcipher\")
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ include/crypto/null.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/include/crypto/null.h b/include/crypto/null.h
+index 0ef577cc00e3..22c3f2274b65 100644
+--- a/include/crypto/null.h
++++ b/include/crypto/null.h
+@@ -9,7 +9,18 @@
+ #define NULL_DIGEST_SIZE	0
+ #define NULL_IV_SIZE		0
+ 
++#ifndef __GENKSYMS__
++/**
++ * Backport of 8d6053984258 ("crypto: null - Remove VLA usage of skcipher")
++ * changed the return type from crypto_skcipher to crypto_sync_skcipher,
++ * but the later is pretty much an alias to the former, used to know which
++ * sub-system are still using Variable Length Arrays stack allocations.
++ */
+ struct crypto_sync_skcipher *crypto_get_default_null_skcipher(void);
++#else
++struct crypto_skcipher *crypto_get_default_null_skcipher(void);
++#endif
++
+ void crypto_put_default_null_skcipher(void);
+ 
+ #endif

--- a/SOURCES/0004-crypto-algif_skcipher-Cap-recv-SG-list-at-ctx-used.patch
+++ b/SOURCES/0004-crypto-algif_skcipher-Cap-recv-SG-list-at-ctx-used.patch
@@ -1,0 +1,39 @@
+From 2202e7ab0576ef46db5ba2d273ca0708c38e68ce Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Fri, 29 May 2020 14:54:43 +1000
+Subject: [PATCH] crypto: algif_skcipher - Cap recv SG list at ctx->used
+
+Somewhere along the line the cap on the SG list length for receive
+was lost.  This patch restores it and removes the subsequent test
+which is now redundant.
+
+Fixes: 2d97591ef43d ("crypto: af_alg - consolidation of...")
+Cc: <stable@vger.kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Reviewed-by: Stephan Mueller <smueller@chronox.de>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_skcipher.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index cfdaab2b7d76..1380a208b8ca 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -78,14 +78,10 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		return PTR_ERR(areq);
+ 
+ 	/* convert iovecs of output buffers into RX SGL */
+-	err = af_alg_get_rsgl(sk, msg, flags, areq, -1, &len);
++	err = af_alg_get_rsgl(sk, msg, flags, areq, ctx->used, &len);
+ 	if (err)
+ 		goto free;
+ 
+-	/* Process only as much RX buffers for which we have TX data */
+-	if (len > ctx->used)
+-		len = ctx->used;
+-
+ 	/*
+ 	 * If more buffers are to be expected to be processed, process only
+ 	 * full block size buffers.

--- a/SOURCES/0005-crypto-af_alg-Use-bh_lock_sock-in-sk_destruct.patch
+++ b/SOURCES/0005-crypto-af_alg-Use-bh_lock_sock-in-sk_destruct.patch
@@ -1,0 +1,45 @@
+From 23cbc4ac4fc095bc7f5e23bbd14cd998c2fa944a Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 5 Dec 2019 13:45:05 +0800
+Subject: [PATCH] crypto: af_alg - Use bh_lock_sock in sk_destruct
+
+commit 37f96694cf73ba116993a9d2d99ad6a75fa7fdb0 upstream.
+
+As af_alg_release_parent may be called from BH context (most notably
+due to an async request that only completes after socket closure,
+or as reported here because of an RCU-delayed sk_destruct call), we
+must use bh_lock_sock instead of lock_sock.
+
+Reported-by: syzbot+c2f1558d49e25cc36e5e@syzkaller.appspotmail.com
+Reported-by: Eric Dumazet <eric.dumazet@gmail.com>
+Fixes: c840ac6af3f8 ("crypto: af_alg - Disallow bind/setkey/...")
+Cc: <stable@vger.kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+(cherry picked from commit 6b544caa07e5672b69f2a8e5f80d72fa4ecf7671)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index ec78a04eb136..644d893561b8 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -139,11 +139,13 @@ void af_alg_release_parent(struct sock *sk)
+ 	sk = ask->parent;
+ 	ask = alg_sk(sk);
+ 
+-	lock_sock(sk);
++	local_bh_disable();
++	bh_lock_sock(sk);
+ 	ask->nokey_refcnt -= nokey;
+ 	if (!last)
+ 		last = !--ask->refcnt;
+-	release_sock(sk);
++	bh_unlock_sock(sk);
++	local_bh_enable();
+ 
+ 	if (last)
+ 		sock_put(sk);

--- a/SOURCES/0006-crypto-af_alg-fix-use-after-free-in-af_alg_accept-du.patch
+++ b/SOURCES/0006-crypto-af_alg-fix-use-after-free-in-af_alg_accept-du.patch
@@ -1,0 +1,202 @@
+From 794706b542412f6c3966ff04d2085e52472d820b Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Mon, 8 Jun 2020 16:48:43 +1000
+Subject: [PATCH] crypto: af_alg - fix use-after-free in af_alg_accept() due to
+ bh_lock_sock()
+
+commit 34c86f4c4a7be3b3e35aa48bd18299d4c756064d upstream.
+
+The locking in af_alg_release_parent is broken as the BH socket
+lock can only be taken if there is a code-path to handle the case
+where the lock is owned by process-context.  Instead of adding
+such handling, we can fix this by changing the ref counts to
+atomic_t.
+
+This patch also modifies the main refcnt to include both normal
+and nokey sockets.  This way we don't have to fudge the nokey
+ref count when a socket changes from nokey to normal.
+
+Credits go to Mauricio Faria de Oliveira who diagnosed this bug
+and sent a patch for it:
+
+https://lore.kernel.org/linux-crypto/20200605161657.535043-1-mfo@canonical.com/
+
+Reported-by: Brian Moyles <bmoyles@netflix.com>
+Reported-by: Mauricio Faria de Oliveira <mfo@canonical.com>
+Fixes: 37f96694cf73 ("crypto: af_alg - Use bh_lock_sock in...")
+Cc: <stable@vger.kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+(cherry picked from commit 9a8ecc6a3ebe625eddd6e96f419762b198de93ce)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 26 +++++++++++---------------
+ crypto/algif_aead.c     |  9 +++------
+ crypto/algif_hash.c     |  9 +++------
+ crypto/algif_skcipher.c |  9 +++------
+ include/crypto/if_alg.h |  4 ++--
+ 5 files changed, 22 insertions(+), 35 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 644d893561b8..4e5d7d9448f0 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -133,21 +133,15 @@ EXPORT_SYMBOL_GPL(af_alg_release);
+ void af_alg_release_parent(struct sock *sk)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+-	unsigned int nokey = ask->nokey_refcnt;
+-	bool last = nokey && !ask->refcnt;
++	unsigned int nokey = atomic_read(&ask->nokey_refcnt);
+ 
+ 	sk = ask->parent;
+ 	ask = alg_sk(sk);
+ 
+-	local_bh_disable();
+-	bh_lock_sock(sk);
+-	ask->nokey_refcnt -= nokey;
+-	if (!last)
+-		last = !--ask->refcnt;
+-	bh_unlock_sock(sk);
+-	local_bh_enable();
++	if (nokey)
++		atomic_dec(&ask->nokey_refcnt);
+ 
+-	if (last)
++	if (atomic_dec_and_test(&ask->refcnt))
+ 		sock_put(sk);
+ }
+ EXPORT_SYMBOL_GPL(af_alg_release_parent);
+@@ -192,7 +186,7 @@ static int alg_bind(struct socket *sock, struct sockaddr *uaddr, int addr_len)
+ 
+ 	err = -EBUSY;
+ 	lock_sock(sk);
+-	if (ask->refcnt | ask->nokey_refcnt)
++	if (atomic_read(&ask->refcnt))
+ 		goto unlock;
+ 
+ 	swap(ask->type, type);
+@@ -241,7 +235,7 @@ static int alg_setsockopt(struct socket *sock, int level, int optname,
+ 	int err = -EBUSY;
+ 
+ 	lock_sock(sk);
+-	if (ask->refcnt)
++	if (atomic_read(&ask->refcnt) != atomic_read(&ask->nokey_refcnt))
+ 		goto unlock;
+ 
+ 	type = ask->type;
+@@ -308,12 +302,14 @@ int af_alg_accept(struct sock *sk, struct socket *newsock, bool kern)
+ 
+ 	sk2->sk_family = PF_ALG;
+ 
+-	if (nokey || !ask->refcnt++)
++	if (atomic_inc_return_relaxed(&ask->refcnt) == 1)
+ 		sock_hold(sk);
+-	ask->nokey_refcnt += nokey;
++	if (nokey) {
++		atomic_inc(&ask->nokey_refcnt);
++		atomic_set(&alg_sk(sk2)->nokey_refcnt, 1);
++	}
+ 	alg_sk(sk2)->parent = sk;
+ 	alg_sk(sk2)->type = type;
+-	alg_sk(sk2)->nokey_refcnt = nokey;
+ 
+ 	newsock->ops = type->ops;
+ 	newsock->state = SS_CONNECTED;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index eb100a04ce9f..e643d268c7ba 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -388,7 +388,7 @@ static int aead_check_key(struct socket *sock)
+ 	struct alg_sock *ask = alg_sk(sk);
+ 
+ 	lock_sock(sk);
+-	if (ask->refcnt)
++	if (!atomic_read(&ask->nokey_refcnt))
+ 		goto unlock_child;
+ 
+ 	psk = ask->parent;
+@@ -400,11 +400,8 @@ static int aead_check_key(struct socket *sock)
+ 	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
+ 		goto unlock;
+ 
+-	if (!pask->refcnt++)
+-		sock_hold(psk);
+-
+-	ask->refcnt = 1;
+-	sock_put(psk);
++	atomic_dec(&pask->nokey_refcnt);
++	atomic_set(&ask->nokey_refcnt, 0);
+ 
+ 	err = 0;
+ 
+diff --git a/crypto/algif_hash.c b/crypto/algif_hash.c
+index bfcf595fd8f9..42521d0d7bfe 100644
+--- a/crypto/algif_hash.c
++++ b/crypto/algif_hash.c
+@@ -306,7 +306,7 @@ static int hash_check_key(struct socket *sock)
+ 	struct alg_sock *ask = alg_sk(sk);
+ 
+ 	lock_sock(sk);
+-	if (ask->refcnt)
++	if (!atomic_read(&ask->nokey_refcnt))
+ 		goto unlock_child;
+ 
+ 	psk = ask->parent;
+@@ -318,11 +318,8 @@ static int hash_check_key(struct socket *sock)
+ 	if (crypto_ahash_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		goto unlock;
+ 
+-	if (!pask->refcnt++)
+-		sock_hold(psk);
+-
+-	ask->refcnt = 1;
+-	sock_put(psk);
++	atomic_dec(&pask->nokey_refcnt);
++	atomic_set(&ask->nokey_refcnt, 0);
+ 
+ 	err = 0;
+ 
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 1380a208b8ca..1cb106c46043 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -215,7 +215,7 @@ static int skcipher_check_key(struct socket *sock)
+ 	struct alg_sock *ask = alg_sk(sk);
+ 
+ 	lock_sock(sk);
+-	if (ask->refcnt)
++	if (!atomic_read(&ask->nokey_refcnt))
+ 		goto unlock_child;
+ 
+ 	psk = ask->parent;
+@@ -227,11 +227,8 @@ static int skcipher_check_key(struct socket *sock)
+ 	if (crypto_skcipher_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		goto unlock;
+ 
+-	if (!pask->refcnt++)
+-		sock_hold(psk);
+-
+-	ask->refcnt = 1;
+-	sock_put(psk);
++	atomic_dec(&pask->nokey_refcnt);
++	atomic_set(&ask->nokey_refcnt, 0);
+ 
+ 	err = 0;
+ 
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 482461d8931d..11f107df78dc 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -34,8 +34,8 @@ struct alg_sock {
+ 
+ 	struct sock *parent;
+ 
+-	unsigned int refcnt;
+-	unsigned int nokey_refcnt;
++	atomic_t refcnt;
++	atomic_t nokey_refcnt;
+ 
+ 	const struct af_alg_type *type;
+ 	void *private;

--- a/SOURCES/0007-kabi-crypto-af_alg-fix-use-after-free-in-af_alg_acce.patch
+++ b/SOURCES/0007-kabi-crypto-af_alg-fix-use-after-free-in-af_alg_acce.patch
@@ -1,0 +1,67 @@
+From fc86a5578afad47cfdab2de24417a6ff3f74bd6c Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Mon, 11 May 2026 16:22:41 +0200
+Subject: [PATCH] !kabi crypto: af_alg - fix use-after-free in af_alg_accept()
+ due to bh_lock_sock()
+
+Everything fits so simply hide the change from genksyms.
+
+Fixes: 794706b54241 ("crypto: af_alg - fix use-after-free in af_alg_accept() due to bh_lock_sock()")
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 20 ++++++++++++++++++++
+ include/crypto/if_alg.h | 11 ++++++++++-
+ 2 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 4e5d7d9448f0..e7d4c09ecc1f 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -1205,3 +1205,23 @@ module_init(af_alg_init);
+ module_exit(af_alg_exit);
+ MODULE_LICENSE("GPL");
+ MODULE_ALIAS_NETPROTO(AF_ALG);
++
++#include <linux/build_bug.h>
++
++void kabi_check_struct_alg_sock(void)
++{
++	struct old_alg_sock {
++		/* struct sock must be the first member of struct alg_sock */
++		struct sock sk;
++
++		struct sock *parent;
++
++		unsigned int refcnt;
++		unsigned int nokey_refcnt;
++
++		const struct af_alg_type *type;
++		void *private;
++	};
++	BUILD_BUG_ON(sizeof(struct old_alg_sock) != sizeof(struct alg_sock));
++	BUILD_BUG_ON(offsetof(struct old_alg_sock, type) != offsetof(struct alg_sock, type));
++}
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 11f107df78dc..f96b17862507 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -34,9 +34,18 @@ struct alg_sock {
+ 
+ 	struct sock *parent;
+ 
++#ifdef __GENKSYMS__
++	/**
++	 * Changed from unsigned int to atomic_t in 794706b54241 ("crypto:
++	 * af_alg - fix use-after-free in af_alg_accept() due to
++	 * bh_lock_sock()") - both are using 4 bytes.
++	 */
++	unsigned int refcnt;
++	unsigned int nokey_refcnt;
++#else
+ 	atomic_t refcnt;
+ 	atomic_t nokey_refcnt;
+-
++#endif
+ 	const struct af_alg_type *type;
+ 	void *private;
+ };

--- a/SOURCES/0008-crypto-algif_aead-Only-wake-up-when-ctx-more-is-zero.patch
+++ b/SOURCES/0008-crypto-algif_aead-Only-wake-up-when-ctx-more-is-zero.patch
@@ -1,0 +1,141 @@
+From 4c6368d02759d4e89cc0c7c76b66397fee52ec16 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Sat, 30 May 2020 00:23:49 +1000
+Subject: [PATCH] crypto: algif_aead - Only wake up when ctx->more is zero
+
+AEAD does not support partial requests so we must not wake up
+while ctx->more is set.  In order to distinguish between the
+case of no data sent yet and a zero-length request, a new init
+flag has been added to ctx.
+
+SKCIPHER has also been modified to ensure that at least a block
+of data is available if there is more data to come.
+
+Fixes: 2d97591ef43d ("crypto: af_alg - consolidation of...")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+(cherry picked from commit f3c802a1f30013f8f723b62d7fa49eb9e991da23)
+
+Context conflicts in include/crypto/if_alg.h due to missing
+466e0759269d ("crypto: af_alg - make some functions static"), not required
+to backport as the conflict resolution is to leave af_alg_data_wakeup() in
+the context.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 11 ++++++++---
+ crypto/algif_aead.c     |  4 ++--
+ crypto/algif_skcipher.c |  4 ++--
+ include/crypto/if_alg.h |  4 +++-
+ 4 files changed, 15 insertions(+), 8 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index e7d4c09ecc1f..b90d3613e4df 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -646,6 +646,7 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 
+ 	if (!ctx->used)
+ 		ctx->merge = 0;
++	ctx->init = ctx->more;
+ }
+ EXPORT_SYMBOL_GPL(af_alg_pull_tsgl);
+ 
+@@ -747,9 +748,10 @@ EXPORT_SYMBOL_GPL(af_alg_wmem_wakeup);
+  *
+  * @sk socket of connection to user space
+  * @flags If MSG_DONTWAIT is set, then only report if function would sleep
++ * @min Set to minimum request size if partial requests are allowed.
+  * @return 0 when writable memory is available, < 0 upon error
+  */
+-int af_alg_wait_for_data(struct sock *sk, unsigned flags)
++int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min)
+ {
+ 	DEFINE_WAIT_FUNC(wait, woken_wake_function);
+ 	struct alg_sock *ask = alg_sk(sk);
+@@ -767,7 +769,9 @@ int af_alg_wait_for_data(struct sock *sk, unsigned flags)
+ 		if (signal_pending(current))
+ 			break;
+ 		timeout = MAX_SCHEDULE_TIMEOUT;
+-		if (sk_wait_event(sk, &timeout, (ctx->used || !ctx->more),
++		if (sk_wait_event(sk, &timeout,
++				  ctx->init && (!ctx->more ||
++						(min && ctx->used >= min)),
+ 				  &wait)) {
+ 			err = 0;
+ 			break;
+@@ -858,7 +862,7 @@ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 	}
+ 
+ 	lock_sock(sk);
+-	if (!ctx->more && ctx->used) {
++	if (ctx->init && (init || !ctx->more)) {
+ 		err = -EINVAL;
+ 		goto unlock;
+ 	}
+@@ -869,6 +873,7 @@ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 			memcpy(ctx->iv, con.iv->iv, ivsize);
+ 
+ 		ctx->aead_assoclen = con.aead_assoclen;
++		ctx->init = true;
+ 	}
+ 
+ 	while (size) {
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index e643d268c7ba..c437ed26719c 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -110,8 +110,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	size_t usedpages = 0;		/* [in]  RX bufs to be used from user */
+ 	size_t processed = 0;		/* [in]  TX bufs to be consumed */
+ 
+-	if (!ctx->used) {
+-		err = af_alg_wait_for_data(sk, flags);
++	if (!ctx->init || ctx->more) {
++		err = af_alg_wait_for_data(sk, flags, 0);
+ 		if (err)
+ 			return err;
+ 	}
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 1cb106c46043..7a6afe4b3b70 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -65,8 +65,8 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	int err = 0;
+ 	size_t len = 0;
+ 
+-	if (!ctx->used) {
+-		err = af_alg_wait_for_data(sk, flags);
++	if (!ctx->init || (ctx->more && ctx->used < bs)) {
++		err = af_alg_wait_for_data(sk, flags, bs);
+ 		if (err)
+ 			return err;
+ 	}
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index f96b17862507..78a5dd172f4f 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -149,6 +149,7 @@ struct af_alg_async_req {
+  *			SG?
+  * @enc:		Cryptographic operation to be performed when
+  *			recvmsg is invoked.
++ * @init:		True if metadata has been sent.
+  * @len:		Length of memory allocated for this data structure.
+  */
+ struct af_alg_ctx {
+@@ -165,6 +166,7 @@ struct af_alg_ctx {
+ 	bool more;
+ 	bool merge;
+ 	bool enc;
++	bool init;
+ 
+ 	unsigned int len;
+ };
+@@ -246,7 +248,7 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ void af_alg_free_areq_sgls(struct af_alg_async_req *areq);
+ int af_alg_wait_for_wmem(struct sock *sk, unsigned int flags);
+ void af_alg_wmem_wakeup(struct sock *sk);
+-int af_alg_wait_for_data(struct sock *sk, unsigned flags);
++int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
+ void af_alg_data_wakeup(struct sock *sk);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 		   unsigned int ivsize);

--- a/SOURCES/0009-kabi-crypto-algif_aead-Only-wake-up-when-ctx-more-is.patch
+++ b/SOURCES/0009-kabi-crypto-algif_aead-Only-wake-up-when-ctx-more-is.patch
@@ -1,0 +1,153 @@
+From 655460b84ad0cc90b0931d479508c17bc78f29d7 Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Mon, 4 May 2026 14:43:59 +0200
+Subject: [PATCH] !kabi crypto: algif_aead - Only wake up when ctx->more is
+ zero
+
+Two things to take care here regarding kABI invariance:
+
+- struct af_alg_ctx got a new field, `init`, luckily, it ends up right in a
+struct hole:
+
+struct af_alg_ctx {
+	struct list_head           tsgl_list;            /*     0    16 */
+	void *                     iv;                   /*    16     8 */
+	size_t                     aead_assoclen;        /*    24     8 */
+	struct crypto_wait         wait;                 /*    32    40 */
+
+	/* XXX last struct has 4 bytes of padding */
+
+	/* --- cacheline 1 boundary (64 bytes) was 8 bytes ago --- */
+	size_t                     used;                 /*    72     8 */
+	atomic_t                   rcvused;              /*    80     4 */
+	bool                       more;                 /*    84     1 */
+	bool                       merge;                /*    85     1 */
+	bool                       enc;                  /*    86     1 */
+
+	/* XXX 1 byte hole, try to pack */
+
+So simply hide the new field from genksyms and make sure to add a compile
+time assert verifying the struct hasn't changed.
+
+- af_alg_wait_for_data, which is exported, now has an optional `min`
+argument.  Instead, rename the function to af_alg_wait_for_data_with_min,
+and keep the prior function af_alg_wait_for_data that calls into it with a
+default `min=0` input argument.
+
+Fixes: c191f457864e ("crypto: algif_aead - Only wake up when ctx->more is zero")
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 30 +++++++++++++++++++++++++++++-
+ crypto/algif_aead.c     |  2 +-
+ crypto/algif_skcipher.c |  2 +-
+ include/crypto/if_alg.h | 11 ++++++++++-
+ 4 files changed, 41 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index b90d3613e4df..9629bbde493b 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -751,7 +751,7 @@ EXPORT_SYMBOL_GPL(af_alg_wmem_wakeup);
+  * @min Set to minimum request size if partial requests are allowed.
+  * @return 0 when writable memory is available, < 0 upon error
+  */
+-int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min)
++int af_alg_wait_for_data_with_min(struct sock *sk, unsigned flags, unsigned min)
+ {
+ 	DEFINE_WAIT_FUNC(wait, woken_wake_function);
+ 	struct alg_sock *ask = alg_sk(sk);
+@@ -783,6 +783,12 @@ int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min)
+ 
+ 	return err;
+ }
++EXPORT_SYMBOL_GPL(af_alg_wait_for_data_with_min);
++
++int af_alg_wait_for_data(struct sock *sk, unsigned flags)
++{
++	return af_alg_wait_for_data_with_min(sk, flags, 0);
++}
+ EXPORT_SYMBOL_GPL(af_alg_wait_for_data);
+ 
+ /**
+@@ -1230,3 +1236,25 @@ void kabi_check_struct_alg_sock(void)
+ 	BUILD_BUG_ON(sizeof(struct old_alg_sock) != sizeof(struct alg_sock));
+ 	BUILD_BUG_ON(offsetof(struct old_alg_sock, type) != offsetof(struct alg_sock, type));
+ }
++
++void kabi_check_struct_af_alg_ctx(void)
++{
++	struct old_af_alg_ctx {
++		struct list_head tsgl_list;
++
++		void *iv;
++		size_t aead_assoclen;
++
++		struct crypto_wait wait;
++
++		size_t used;
++		atomic_t rcvused;
++
++		bool more;
++		bool merge;
++		bool enc;
++		unsigned int len;
++	};
++	BUILD_BUG_ON(sizeof(struct old_af_alg_ctx) != sizeof(struct af_alg_ctx));
++	BUILD_BUG_ON(offsetof(struct old_af_alg_ctx, len) != offsetof(struct af_alg_ctx, len));
++}
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index c437ed26719c..1eadb3491ad2 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -111,7 +111,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	size_t processed = 0;		/* [in]  TX bufs to be consumed */
+ 
+ 	if (!ctx->init || ctx->more) {
+-		err = af_alg_wait_for_data(sk, flags, 0);
++		err = af_alg_wait_for_data_with_min(sk, flags, 0);
+ 		if (err)
+ 			return err;
+ 	}
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 7a6afe4b3b70..9a06cf60bffa 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -66,7 +66,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	size_t len = 0;
+ 
+ 	if (!ctx->init || (ctx->more && ctx->used < bs)) {
+-		err = af_alg_wait_for_data(sk, flags, bs);
++		err = af_alg_wait_for_data_with_min(sk, flags, bs);
+ 		if (err)
+ 			return err;
+ 	}
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 78a5dd172f4f..eddbbf0b1e4c 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -166,7 +166,15 @@ struct af_alg_ctx {
+ 	bool more;
+ 	bool merge;
+ 	bool enc;
++#ifndef __GENKSYMS__
++	/**
++	 * Backports of f3c802a1f300 ("crypto: algif_aead - Only wake up
++	 * when ctx->more is zero") adds this field, which changes the
++	 * kABI.  We can hide it because it fits in a hole.  Verified with
++	 * kabi_check_af_alg_ctx.
++	 */
+ 	bool init;
++#endif
+ 
+ 	unsigned int len;
+ };
+@@ -248,7 +256,8 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ void af_alg_free_areq_sgls(struct af_alg_async_req *areq);
+ int af_alg_wait_for_wmem(struct sock *sk, unsigned int flags);
+ void af_alg_wmem_wakeup(struct sock *sk);
+-int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
++int af_alg_wait_for_data_with_min(struct sock *sk, unsigned flags, unsigned min);
++int af_alg_wait_for_data(struct sock *sk, unsigned flags);
+ void af_alg_data_wakeup(struct sock *sk);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 		   unsigned int ivsize);

--- a/SOURCES/0010-crypto-algif_aead-fix-uninitialized-ctx-init.patch
+++ b/SOURCES/0010-crypto-algif_aead-fix-uninitialized-ctx-init.patch
@@ -1,0 +1,73 @@
+From a65c1457e3ed6f74ac201419a6ce526f089b5018 Mon Sep 17 00:00:00 2001
+From: Ondrej Mosnacek <omosnace@redhat.com>
+Date: Wed, 12 Aug 2020 14:58:25 +0200
+Subject: [PATCH] crypto: algif_aead - fix uninitialized ctx->init
+
+In skcipher_accept_parent_nokey() the whole af_alg_ctx structure is
+cleared by memset() after allocation, so add such memset() also to
+aead_accept_parent_nokey() so that the new "init" field is also
+initialized to zero. Without that the initial ctx->init checks might
+randomly return true and cause errors.
+
+While there, also remove the redundant zero assignments in both
+functions.
+
+Found via libkcapi testsuite.
+
+Cc: Stephan Mueller <smueller@chronox.de>
+Fixes: f3c802a1f300 ("crypto: algif_aead - Only wake up when ctx->more is zero")
+Suggested-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_aead.c     | 6 ------
+ crypto/algif_skcipher.c | 7 +------
+ 2 files changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index 1eadb3491ad2..5e0ed1d31003 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -562,12 +562,6 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ 
+ 	INIT_LIST_HEAD(&ctx->tsgl_list);
+ 	ctx->len = len;
+-	ctx->used = 0;
+-	atomic_set(&ctx->rcvused, 0);
+-	ctx->more = 0;
+-	ctx->merge = 0;
+-	ctx->enc = 0;
+-	ctx->aead_assoclen = 0;
+ 	crypto_init_wait(&ctx->wait);
+ 
+ 	ask->private = ctx;
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 9a06cf60bffa..808798e82f70 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -337,6 +337,7 @@ static int skcipher_accept_parent_nokey(void *private, struct sock *sk)
+ 	ctx = sock_kmalloc(sk, len, GFP_KERNEL);
+ 	if (!ctx)
+ 		return -ENOMEM;
++	memset(ctx, 0, len);
+ 
+ 	ctx->iv = sock_kmalloc(sk, crypto_skcipher_ivsize(tfm),
+ 			       GFP_KERNEL);
+@@ -344,16 +345,10 @@ static int skcipher_accept_parent_nokey(void *private, struct sock *sk)
+ 		sock_kfree_s(sk, ctx, len);
+ 		return -ENOMEM;
+ 	}
+-
+ 	memset(ctx->iv, 0, crypto_skcipher_ivsize(tfm));
+ 
+ 	INIT_LIST_HEAD(&ctx->tsgl_list);
+ 	ctx->len = len;
+-	ctx->used = 0;
+-	atomic_set(&ctx->rcvused, 0);
+-	ctx->more = 0;
+-	ctx->merge = 0;
+-	ctx->enc = 0;
+ 	crypto_init_wait(&ctx->wait);
+ 
+ 	ask->private = ctx;

--- a/SOURCES/0011-crypto-algif_skcipher-EBUSY-on-aio-should-be-an-erro.patch
+++ b/SOURCES/0011-crypto-algif_skcipher-EBUSY-on-aio-should-be-an-erro.patch
@@ -1,0 +1,30 @@
+From 25657f6776c20d9e076c56d9ef50af37f76b8ecc Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Fri, 31 Jul 2020 17:03:27 +1000
+Subject: [PATCH] crypto: algif_skcipher - EBUSY on aio should be an error
+
+I removed the MAY_BACKLOG flag on the aio path a while ago but
+the error check still incorrectly interpreted EBUSY as success.
+This may cause the submitter to wait for a request that will never
+complete.
+
+Fixes: dad419970637 ("crypto: algif_skcipher - Do not set...")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_skcipher.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 808798e82f70..7ea273069a6a 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -127,7 +127,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 			crypto_skcipher_decrypt(&areq->cra_u.skcipher_req);
+ 
+ 		/* AIO operation in progress */
+-		if (err == -EINPROGRESS || err == -EBUSY)
++		if (err == -EINPROGRESS)
+ 			return -EIOCBQUEUED;
+ 
+ 		sock_put(sk);

--- a/SOURCES/0012-crypto-algif_aead-Do-not-set-MAY_BACKLOG-on-the-asyn.patch
+++ b/SOURCES/0012-crypto-algif_aead-Do-not-set-MAY_BACKLOG-on-the-asyn.patch
@@ -1,0 +1,54 @@
+From 1b0fc5595e280541db2b8de14d5733625974b4e6 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Fri, 31 Jul 2020 17:03:50 +1000
+Subject: [PATCH] crypto: algif_aead - Do not set MAY_BACKLOG on the async path
+
+The async path cannot use MAY_BACKLOG because it is not meant to
+block, which is what MAY_BACKLOG does.  On the other hand, both
+the sync and async paths can make use of MAY_SLEEP.
+
+Fixes: 83094e5e9e49 ("crypto: af_alg - add async support to...")
+Cc: <stable@vger.kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+(cherry picked from commit cbdad1f246dd98e6c9c32a6e5212337f542aa7e0)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_aead.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index 5e0ed1d31003..c9212563e875 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -82,7 +82,7 @@ static int crypto_aead_copy_sgl(struct crypto_sync_skcipher *null_tfm,
+ 	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, null_tfm);
+ 
+ 	skcipher_request_set_sync_tfm(skreq, null_tfm);
+-	skcipher_request_set_callback(skreq, CRYPTO_TFM_REQ_MAY_BACKLOG,
++	skcipher_request_set_callback(skreq, CRYPTO_TFM_REQ_MAY_SLEEP,
+ 				      NULL, NULL);
+ 	skcipher_request_set_crypt(skreq, src, dst, len, NULL);
+ 
+@@ -295,19 +295,20 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		areq->outlen = outlen;
+ 
+ 		aead_request_set_callback(&areq->cra_u.aead_req,
+-					  CRYPTO_TFM_REQ_MAY_BACKLOG,
++					  CRYPTO_TFM_REQ_MAY_SLEEP,
+ 					  af_alg_async_cb, areq);
+ 		err = ctx->enc ? crypto_aead_encrypt(&areq->cra_u.aead_req) :
+ 				 crypto_aead_decrypt(&areq->cra_u.aead_req);
+ 
+ 		/* AIO operation in progress */
+-		if (err == -EINPROGRESS || err == -EBUSY)
++		if (err == -EINPROGRESS)
+ 			return -EIOCBQUEUED;
+ 
+ 		sock_put(sk);
+ 	} else {
+ 		/* Synchronous operation */
+ 		aead_request_set_callback(&areq->cra_u.aead_req,
++					  CRYPTO_TFM_REQ_MAY_SLEEP |
+ 					  CRYPTO_TFM_REQ_MAY_BACKLOG,
+ 					  crypto_req_done, &ctx->wait);
+ 		err = crypto_wait_req(ctx->enc ?

--- a/SOURCES/0013-crypto-af_alg-Disallow-multiple-in-flight-AIO-reques.patch
+++ b/SOURCES/0013-crypto-af_alg-Disallow-multiple-in-flight-AIO-reques.patch
@@ -1,0 +1,81 @@
+From 61c669f0a57f8ae52c4aadc3ad76a929736ae557 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Tue, 28 Nov 2023 16:25:49 +0800
+Subject: [PATCH] crypto: af_alg - Disallow multiple in-flight AIO requests
+
+[ Upstream commit 67b164a871af1d736f131fd6fe78a610909f06f3 ]
+
+Having multiple in-flight AIO requests results in unpredictable
+output because they all share the same IV.  Fix this by only allowing
+one request at a time.
+
+Fixes: 83094e5e9e49 ("crypto: af_alg - add async support to algif_aead")
+Fixes: a596999b7ddf ("crypto: algif - change algif_skcipher to be asynchronous")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 14 +++++++++++++-
+ include/crypto/if_alg.h |  3 +++
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 9629bbde493b..7747868739a1 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -1039,9 +1039,13 @@ EXPORT_SYMBOL_GPL(af_alg_sendpage);
+ void af_alg_free_resources(struct af_alg_async_req *areq)
+ {
+ 	struct sock *sk = areq->sk;
++	struct af_alg_ctx *ctx;
+ 
+ 	af_alg_free_areq_sgls(areq);
+ 	sock_kfree_s(sk, areq, areq->areqlen);
++
++	ctx = alg_sk(sk)->private;
++	ctx->inflight = false;
+ }
+ EXPORT_SYMBOL_GPL(af_alg_free_resources);
+ 
+@@ -1105,11 +1109,19 @@ EXPORT_SYMBOL_GPL(af_alg_poll);
+ struct af_alg_async_req *af_alg_alloc_areq(struct sock *sk,
+ 					   unsigned int areqlen)
+ {
+-	struct af_alg_async_req *areq = sock_kmalloc(sk, areqlen, GFP_KERNEL);
++	struct af_alg_ctx *ctx = alg_sk(sk)->private;
++	struct af_alg_async_req *areq;
++
++	/* Only one AIO request can be in flight. */
++	if (ctx->inflight)
++		return ERR_PTR(-EBUSY);
+ 
++	areq = sock_kmalloc(sk, areqlen, GFP_KERNEL);
+ 	if (unlikely(!areq))
+ 		return ERR_PTR(-ENOMEM);
+ 
++	ctx->inflight = true;
++
+ 	areq->areqlen = areqlen;
+ 	areq->sk = sk;
+ 	areq->last_rsgl = NULL;
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index eddbbf0b1e4c..ff885432ec84 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -151,6 +151,7 @@ struct af_alg_async_req {
+  *			recvmsg is invoked.
+  * @init:		True if metadata has been sent.
+  * @len:		Length of memory allocated for this data structure.
++ * @inflight:		Non-zero when AIO requests are in flight.
+  */
+ struct af_alg_ctx {
+ 	struct list_head tsgl_list;
+@@ -177,6 +178,8 @@ struct af_alg_ctx {
+ #endif
+ 
+ 	unsigned int len;
++
++	unsigned int inflight;
+ };
+ 
+ int af_alg_register_type(const struct af_alg_type *type);

--- a/SOURCES/0014-kabi-crypto-af_alg-Disallow-multiple-in-flight-AIO-r.patch
+++ b/SOURCES/0014-kabi-crypto-af_alg-Disallow-multiple-in-flight-AIO-r.patch
@@ -1,0 +1,38 @@
+From 981e3da1587d79c6c538c35fa2ece8c2d368a4a1 Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Mon, 11 May 2026 16:38:29 +0200
+Subject: [PATCH] !kabi crypto: af_alg - Disallow multiple in-flight AIO
+ requests
+
+Fixes: 33af820bb46a ("crypto: af_alg - Disallow multiple in-flight AIO requests")
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ include/crypto/if_alg.h | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index ff885432ec84..10151c3f73c8 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -174,12 +174,19 @@ struct af_alg_ctx {
+ 	 * kABI.  We can hide it because it fits in a hole.  Verified with
+ 	 * kabi_check_af_alg_ctx.
+ 	 */
+-	bool init;
++	bool init:1;
++	/**
++	 * Backport of 67b164a871af ("crypto: af_alg - Disallow multiple
++	 * in-flight AIO requests") added a new inflight field as unsigned
++	 * int.  Convert it to bool:1 such that it can fit in the same hole
++	 * used by the init field above.  Note that init is also converted
++	 * to a bool:1 from bool, otherwise we can't fit both.
++	 */
++	bool inflight:1;
+ #endif
+ 
+ 	unsigned int len;
+ 
+-	unsigned int inflight;
+ };
+ 
+ int af_alg_register_type(const struct af_alg_type *type);

--- a/SOURCES/0015-crypto-af_alg-Work-around-empty-control-messages-wit.patch
+++ b/SOURCES/0015-crypto-af_alg-Work-around-empty-control-messages-wit.patch
@@ -1,0 +1,63 @@
+From 85bfd1ee80233443b13dbbeba2097abe1855bf33 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 27 Aug 2020 17:14:36 +1000
+Subject: [PATCH] crypto: af_alg - Work around empty control messages without
+ MSG_MORE
+
+The iwd daemon uses libell which sets up the skcipher operation with
+two separate control messages.  As the first control message is sent
+without MSG_MORE, it is interpreted as an empty request.
+
+While libell should be fixed to use MSG_MORE where appropriate, this
+patch works around the bug in the kernel so that existing binaries
+continue to work.
+
+We will print a warning however.
+
+A separate issue is that the new kernel code no longer allows the
+control message to be sent twice within the same request.  This
+restriction is obviously incompatible with what iwd was doing (first
+setting an IV and then sending the real control message).  This
+patch changes the kernel so that this is explicitly allowed.
+
+Reported-by: Caleb Jorden <caljorden@hotmail.com>
+Fixes: f3c802a1f300 ("crypto: algif_aead - Only wake up when...")
+Cc: <stable@vger.kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+(cherry picked from commit c195d66a8a75c60515819b101975f38b7ec6577f)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 7747868739a1..c6cfd4c547e7 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -21,6 +21,7 @@
+ #include <linux/module.h>
+ #include <linux/net.h>
+ #include <linux/rwsem.h>
++#include <linux/sched.h>
+ #include <linux/sched/signal.h>
+ #include <linux/security.h>
+ 
+@@ -868,9 +869,15 @@ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 	}
+ 
+ 	lock_sock(sk);
+-	if (ctx->init && (init || !ctx->more)) {
+-		err = -EINVAL;
+-		goto unlock;
++	if (ctx->init && !ctx->more) {
++		if (ctx->used) {
++			err = -EINVAL;
++			goto unlock;
++		}
++
++		pr_info_once(
++			"%s sent an empty control message without MSG_MORE.\n",
++			current->comm);
+ 	}
+ 
+ 	if (init) {

--- a/SOURCES/0016-crypto-af_alg-Disallow-concurrent-writes-in-af_alg_s.patch
+++ b/SOURCES/0016-crypto-af_alg-Disallow-concurrent-writes-in-af_alg_s.patch
@@ -1,0 +1,78 @@
+From 6b1b329b6ff91a91e3d96515e3481628541a4b44 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Tue, 16 Sep 2025 17:20:59 +0800
+Subject: [PATCH] crypto: af_alg - Disallow concurrent writes in af_alg_sendmsg
+
+[ Upstream commit 1b34cbbf4f011a121ef7b2d7d6e6920a036d5285 ]
+
+Issuing two writes to the same af_alg socket is bogus as the
+data will be interleaved in an unpredictable fashion.  Furthermore,
+concurrent writes may create inconsistencies in the internal
+socket state.
+
+Disallow this by adding a new ctx->write field that indiciates
+exclusive ownership for writing.
+
+Fixes: 8ff590903d5 ("crypto: algif_skcipher - User-space interface for skcipher operations")
+Reported-by: Muhammad Alifa Ramdhan <ramdhan@starlabs.sg>
+Reported-by: Bing-Jhong Billy Jheng <billy@starlabs.sg>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+
+(cherry picked from 0f28c4adbc4a97437874c9b669fd7958a8c6d6ce)
+
+Conflict due to our kABI neutralization of the fiield init.  Changed the
+patch to only add the write bitfield instead of changing all prior ones.  A
+subsequent patch will handle the kABI fixing for this new write field.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 7 +++++++
+ include/crypto/if_alg.h | 2 ++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index c6cfd4c547e7..f31abea43ea7 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -869,6 +869,12 @@ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 	}
+ 
+ 	lock_sock(sk);
++	if (ctx->write) {
++		release_sock(sk);
++		return -EBUSY;
++	}
++	ctx->write = true;
++
+ 	if (ctx->init && !ctx->more) {
+ 		if (ctx->used) {
+ 			err = -EINVAL;
+@@ -976,6 +982,7 @@ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 
+ unlock:
+ 	af_alg_data_wakeup(sk);
++	ctx->write = false;
+ 	release_sock(sk);
+ 
+ 	return copied ?: err;
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 10151c3f73c8..3e2700b2e5e9 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -149,6 +149,7 @@ struct af_alg_async_req {
+  *			SG?
+  * @enc:		Cryptographic operation to be performed when
+  *			recvmsg is invoked.
++ * @write:		True if we are in the middle of a write.
+  * @init:		True if metadata has been sent.
+  * @len:		Length of memory allocated for this data structure.
+  * @inflight:		Non-zero when AIO requests are in flight.
+@@ -184,6 +185,7 @@ struct af_alg_ctx {
+ 	 */
+ 	bool inflight:1;
+ #endif
++	u32 write:1;
+ 
+ 	unsigned int len;
+ 

--- a/SOURCES/0017-crypto-af_alg-Fix-incorrect-boolean-values-in-af_alg.patch
+++ b/SOURCES/0017-crypto-af_alg-Fix-incorrect-boolean-values-in-af_alg.patch
@@ -1,0 +1,52 @@
+From 87694056e6dcbae97503b970864147471825eb18 Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Thu, 7 May 2026 11:03:13 +0200
+Subject: [PATCH] crypto: af_alg - Fix incorrect boolean values in af_alg_ctx
+
+[ Upstream commit d0ca0df179c4b21e2a6c4a4fb637aa8fa14575cb ]
+
+Commit 1b34cbbf4f01 ("crypto: af_alg - Disallow concurrent writes in
+af_alg_sendmsg") changed some fields from bool to 1-bit bitfields of
+type u32.
+
+However, some assignments to these fields, specifically 'more' and
+'merge', assign values greater than 1.  These relied on C's implicit
+conversion to bool, such that zero becomes false and nonzero becomes
+true.
+
+With a 1-bit bitfields of type u32 instead, mod 2 of the value is taken
+instead, resulting in 0 being assigned in some cases when 1 was intended.
+
+Fix this by restoring the bool type.
+
+Fixes: 1b34cbbf4f01 ("crypto: af_alg - Disallow concurrent writes in af_alg_sendmsg")
+Cc: stable@vger.kernel.org
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+
+(cherry picked from 3a21698ace915a445bce2d0dcfc84b6d2199baf7)
+
+Again, conflict due to our prior kABI neutralization of the init field, so
+converting back to bool only the 'write' field, although not really
+necessary because it was only ever assigned 0 or 1 unlike some other
+fields, this just make it obvious that we're not missing a patch here.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ include/crypto/if_alg.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 3e2700b2e5e9..1e70cde85f4c 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -185,7 +185,7 @@ struct af_alg_ctx {
+ 	 */
+ 	bool inflight:1;
+ #endif
+-	u32 write:1;
++	bool write:1;
+ 
+ 	unsigned int len;
+ 

--- a/SOURCES/0018-kabi-crypto-af_alg-Fix-incorrect-boolean-values-in-a.patch
+++ b/SOURCES/0018-kabi-crypto-af_alg-Fix-incorrect-boolean-values-in-a.patch
@@ -1,0 +1,34 @@
+From 9ea3e02e1b88e27b902aa705acf151ce3312c54f Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Mon, 11 May 2026 16:31:00 +0200
+Subject: [PATCH] !kabi crypto: af_alg - Fix incorrect boolean values in
+ af_alg_ctx
+
+Fixes: 89f45308f42d ("crypto: af_alg - Fix incorrect boolean values in af_alg_ctx")
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ include/crypto/if_alg.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 1e70cde85f4c..e178090808c6 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -184,8 +184,16 @@ struct af_alg_ctx {
+ 	 * to a bool:1 from bool, otherwise we can't fit both.
+ 	 */
+ 	bool inflight:1;
+-#endif
++	/**
++	 * Backport of 3a21698ace91 ("crypto: af_alg - Fix incorrect
++	 * boolean values in af_alg_ctx") + 1b34cbbf4f01 ("crypto: af_alg -
++	 * Disallow concurrent writes in af_alg_sendmsg") added this field
++	 * (first as u32:1 then as bool:1).  Luckily the above init and
++	 * inflight fields were also added in this branch as bool:1, so
++	 * convert write to bool:1 too so it can fit in the hole.
++	 */
+ 	bool write:1;
++#endif
+ 
+ 	unsigned int len;
+ 

--- a/SOURCES/0019-crypto-authencesn-reject-too-short-AAD-assoclen-8-to.patch
+++ b/SOURCES/0019-crypto-authencesn-reject-too-short-AAD-assoclen-8-to.patch
@@ -1,0 +1,50 @@
+From c2ba3c7ef31f2a09697dfe9f214ccd08824618fc Mon Sep 17 00:00:00 2001
+From: Taeyang Lee <0wn@theori.io>
+Date: Fri, 16 Jan 2026 16:03:58 +0900
+Subject: [PATCH] crypto: authencesn - reject too-short AAD (assoclen<8) to
+ match ESP/ESN spec
+
+[ Upstream commit 2397e9264676be7794f8f7f1e9763d90bd3c7335 ]
+
+authencesn assumes an ESP/ESN-formatted AAD. When assoclen is shorter than
+the minimum expected length, crypto_authenc_esn_decrypt() can advance past
+the end of the destination scatterlist and trigger a NULL pointer dereference
+in scatterwalk_map_and_copy(), leading to a kernel panic (DoS).
+
+Add a minimum AAD length check to fail fast on invalid inputs.
+
+Fixes: 104880a6b470 ("crypto: authencesn - Convert to new AEAD interface")
+Reported-By: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+(cherry picked from commit df22c9a65e9a9daa368a72fed596af9d7d5876bb)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/authencesn.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+index 4741fe89ba2c..49be114eaee5 100644
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -206,6 +206,9 @@ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ 	struct scatterlist *src, *dst;
+ 	int err;
+ 
++	if (assoclen < 8)
++		return -EINVAL;
++
+ 	sg_init_table(areq_ctx->src, 2);
+ 	src = scatterwalk_ffwd(areq_ctx->src, req->src, assoclen);
+ 	dst = src;
+@@ -299,6 +302,9 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	u32 tmp[2];
+ 	int err;
+ 
++	if (assoclen < 8)
++		return -EINVAL;
++
+ 	cryptlen -= authsize;
+ 
+ 	if (req->src != dst) {

--- a/SOURCES/0020-crypto-af-alg-fix-NULL-pointer-dereference-in-scatte.patch
+++ b/SOURCES/0020-crypto-af-alg-fix-NULL-pointer-dereference-in-scatte.patch
@@ -1,0 +1,44 @@
+From 017bc8f580fc2b4950362735b2eef166a9577e0d Mon Sep 17 00:00:00 2001
+From: Norbert Szetei <norbert@doyensec.com>
+Date: Wed, 25 Mar 2026 18:26:13 +0100
+Subject: [PATCH] crypto: af-alg - fix NULL pointer dereference in scatterwalk
+
+[ Upstream commit 62397b493e14107ae82d8b80938f293d95425bcb ]
+
+The AF_ALG interface fails to unmark the end of a Scatter/Gather List (SGL)
+when chaining a new af_alg_tsgl structure. If a sendmsg() fills an SGL
+exactly to MAX_SGL_ENTS, the last entry is marked as the end. A subsequent
+sendmsg() allocates a new SGL and chains it, but fails to clear the end
+marker on the previous SGL's last data entry.
+
+This causes the crypto scatterwalk to hit a premature end, returning NULL
+on sg_next() and leading to a kernel panic during dereference.
+
+Fix this by explicitly unmarking the end of the previous SGL when
+performing sg_chain() in af_alg_alloc_tsgl().
+
+Fixes: 8ff590903d5f ("crypto: algif_skcipher - User-space interface for skcipher operations")
+Signed-off-by: Norbert Szetei <norbert@doyensec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index f31abea43ea7..a11b3d22ef9a 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -510,8 +510,10 @@ int af_alg_alloc_tsgl(struct sock *sk)
+ 		sg_init_table(sgl->sg, MAX_SGL_ENTS + 1);
+ 		sgl->cur = 0;
+ 
+-		if (sg)
++		if (sg) {
++			sg_unmark_end(sg + MAX_SGL_ENTS - 1);
+ 			sg_chain(sg, MAX_SGL_ENTS + 1, sgl->sg);
++		}
+ 
+ 		list_add_tail(&sgl->list, &ctx->tsgl_list);
+ 	}

--- a/SOURCES/0021-crypto-authenc-use-memcpy_sglist-instead-of-null-skc.patch
+++ b/SOURCES/0021-crypto-authenc-use-memcpy_sglist-instead-of-null-skc.patch
@@ -1,0 +1,237 @@
+From 88107ffe03a491eedd223274222e31f0b2640c7d Mon Sep 17 00:00:00 2001
+From: Eric Biggers <ebiggers@google.com>
+Date: Thu, 30 Apr 2026 00:01:24 -0700
+Subject: [PATCH] crypto: authenc - use memcpy_sglist() instead of null
+ skcipher
+
+commit dbc4b1458e931e47198c3165ff5853bc1ad6bd7a upstream.
+
+For copying data between two scatterlists, just use memcpy_sglist()
+instead of the so-called "null skcipher".  This is much simpler.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 274857bb1fbef99ce4dba0f6e940115e17c48361)
+(cherry picked from commit bf6fc7bc6a0bb3fc765678e62433af3174bc4ecc)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/Kconfig      |  1 -
+ crypto/authenc.c    | 32 +-------------------------------
+ crypto/authencesn.c | 38 +++-----------------------------------
+ 3 files changed, 4 insertions(+), 67 deletions(-)
+
+diff --git a/crypto/Kconfig b/crypto/Kconfig
+index 59e32623a7ce..34926ae336c3 100644
+--- a/crypto/Kconfig
++++ b/crypto/Kconfig
+@@ -233,7 +233,6 @@ config CRYPTO_AUTHENC
+ 	select CRYPTO_BLKCIPHER
+ 	select CRYPTO_MANAGER
+ 	select CRYPTO_HASH
+-	select CRYPTO_NULL
+ 	help
+ 	  Authenc: Combined mode wrapper for IPsec.
+ 	  This is required for IPSec.
+diff --git a/crypto/authenc.c b/crypto/authenc.c
+index 4be293a4b5f0..c7602179cae4 100644
+--- a/crypto/authenc.c
++++ b/crypto/authenc.c
+@@ -14,7 +14,6 @@
+ #include <crypto/internal/hash.h>
+ #include <crypto/internal/skcipher.h>
+ #include <crypto/authenc.h>
+-#include <crypto/null.h>
+ #include <crypto/scatterwalk.h>
+ #include <linux/err.h>
+ #include <linux/init.h>
+@@ -33,7 +32,6 @@ struct authenc_instance_ctx {
+ struct crypto_authenc_ctx {
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_request_ctx {
+@@ -189,21 +187,6 @@ static void crypto_authenc_encrypt_done(struct crypto_async_request *req,
+ 	authenc_request_complete(areq, err);
+ }
+ 
+-static int crypto_authenc_copy_assoc(struct aead_request *req)
+-{
+-	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+-	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(authenc);
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+-
+-	skcipher_request_set_sync_tfm(skreq, ctx->null);
+-	skcipher_request_set_callback(skreq, aead_request_flags(req),
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, req->src, req->dst, req->assoclen,
+-				   NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int crypto_authenc_encrypt(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+@@ -222,10 +205,7 @@ static int crypto_authenc_encrypt(struct aead_request *req)
+ 	dst = src;
+ 
+ 	if (req->src != req->dst) {
+-		err = crypto_authenc_copy_assoc(req);
+-		if (err)
+-			return err;
+-
++		memcpy_sglist(req->dst, req->src, req->assoclen);
+ 		dst = scatterwalk_ffwd(areq_ctx->dst, req->dst, req->assoclen);
+ 	}
+ 
+@@ -326,7 +306,6 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+@@ -338,14 +317,8 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	if (IS_ERR(enc))
+ 		goto err_free_ahash;
+ 
+-	null = crypto_get_default_null_skcipher();
+-	err = PTR_ERR(null);
+-	if (IS_ERR(null))
+-		goto err_free_skcipher;
+-
+ 	ctx->auth = auth;
+ 	ctx->enc = enc;
+-	ctx->null = null;
+ 
+ 	crypto_aead_set_reqsize(
+ 		tfm,
+@@ -359,8 +332,6 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 
+ 	return 0;
+ 
+-err_free_skcipher:
+-	crypto_free_skcipher(enc);
+ err_free_ahash:
+ 	crypto_free_ahash(auth);
+ 	return err;
+@@ -372,7 +343,6 @@ static void crypto_authenc_exit_tfm(struct crypto_aead *tfm)
+ 
+ 	crypto_free_ahash(ctx->auth);
+ 	crypto_free_skcipher(ctx->enc);
+-	crypto_put_default_null_skcipher();
+ }
+ 
+ static void crypto_authenc_free(struct aead_instance *inst)
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+index 49be114eaee5..c6416070ea71 100644
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -17,7 +17,6 @@
+ #include <crypto/internal/hash.h>
+ #include <crypto/internal/skcipher.h>
+ #include <crypto/authenc.h>
+-#include <crypto/null.h>
+ #include <crypto/scatterwalk.h>
+ #include <linux/err.h>
+ #include <linux/init.h>
+@@ -36,7 +35,6 @@ struct crypto_authenc_esn_ctx {
+ 	unsigned int reqoff;
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_esn_request_ctx {
+@@ -179,20 +177,6 @@ static void crypto_authenc_esn_encrypt_done(struct crypto_async_request *req,
+ 	authenc_esn_request_complete(areq, err);
+ }
+ 
+-static int crypto_authenc_esn_copy(struct aead_request *req, unsigned int len)
+-{
+-	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+-	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(authenc_esn);
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+-
+-	skcipher_request_set_sync_tfm(skreq, ctx->null);
+-	skcipher_request_set_callback(skreq, aead_request_flags(req),
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, req->src, req->dst, len, NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+@@ -214,10 +198,7 @@ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ 	dst = src;
+ 
+ 	if (req->src != req->dst) {
+-		err = crypto_authenc_esn_copy(req, assoclen);
+-		if (err)
+-			return err;
+-
++		memcpy_sglist(req->dst, req->src, assoclen);
+ 		sg_init_table(areq_ctx->dst, 2);
+ 		dst = scatterwalk_ffwd(areq_ctx->dst, req->dst, assoclen);
+ 	}
+@@ -307,11 +288,8 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 
+ 	cryptlen -= authsize;
+ 
+-	if (req->src != dst) {
+-		err = crypto_authenc_esn_copy(req, assoclen + cryptlen);
+-		if (err)
+-			return err;
+-	}
++	if (req->src != dst)
++		memcpy_sglist(dst, req->src, assoclen + cryptlen);
+ 
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+@@ -347,7 +325,6 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+@@ -359,14 +336,8 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	if (IS_ERR(enc))
+ 		goto err_free_ahash;
+ 
+-	null = crypto_get_default_null_skcipher();
+-	err = PTR_ERR(null);
+-	if (IS_ERR(null))
+-		goto err_free_skcipher;
+-
+ 	ctx->auth = auth;
+ 	ctx->enc = enc;
+-	ctx->null = null;
+ 
+ 	ctx->reqoff = ALIGN(2 * crypto_ahash_digestsize(auth),
+ 			    crypto_ahash_alignmask(auth) + 1);
+@@ -383,8 +354,6 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 
+ 	return 0;
+ 
+-err_free_skcipher:
+-	crypto_free_skcipher(enc);
+ err_free_ahash:
+ 	crypto_free_ahash(auth);
+ 	return err;
+@@ -396,7 +365,6 @@ static void crypto_authenc_esn_exit_tfm(struct crypto_aead *tfm)
+ 
+ 	crypto_free_ahash(ctx->auth);
+ 	crypto_free_skcipher(ctx->enc);
+-	crypto_put_default_null_skcipher();
+ }
+ 
+ static void crypto_authenc_esn_free(struct aead_instance *inst)

--- a/SOURCES/0022-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst-f.patch
+++ b/SOURCES/0022-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst-f.patch
@@ -1,0 +1,122 @@
+From 89bc6e3963d2b49e69f0cf91825df594379a1054 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 30 Apr 2026 00:01:25 -0700
+Subject: [PATCH] crypto: authencesn - Do not place hiseq at end of dst for
+ out-of-place decryption
+
+commit e02494114ebf7c8b42777c6cd6982f113bfdbec7 upstream.
+
+When decrypting data that is not in-place (src != dst), there is
+no need to save the high-order sequence bits in dst as it could
+simply be re-copied from the source.
+
+However, the data to be hashed need to be rearranged accordingly.
+
+Reported-by: Taeyang Lee <0wn@theori.io>
+Fixes: 104880a6b470 ("crypto: authencesn - Convert to new AEAD interface")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 8c62f618576519dbed6816fafc623ce592953025)
+(cherry picked from commit 3b73d523b1f63badc98df53e7a1b39ea61f12cdf)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/authencesn.c | 48 +++++++++++++++++++++++++++------------------
+ 1 file changed, 29 insertions(+), 19 deletions(-)
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+index c6416070ea71..d3731ac1d156 100644
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -229,6 +229,7 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 			      crypto_ahash_alignmask(auth) + 1);
+ 	unsigned int cryptlen = req->cryptlen - authsize;
+ 	unsigned int assoclen = req->assoclen;
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
+ 	u32 tmp[2];
+@@ -236,23 +237,27 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 	if (!authsize)
+ 		goto decrypt;
+ 
+-	/* Move high-order bits of sequence number back. */
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	if (src == dst) {
++		/* Move high-order bits of sequence number back. */
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
++		scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	} else
++		memcpy_sglist(dst, src, assoclen);
+ 
+ 	if (crypto_memneq(ihash, ohash, authsize))
+ 		return -EBADMSG;
+ 
+ decrypt:
+ 
+-	sg_init_table(areq_ctx->dst, 2);
++	if (src != dst)
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,
+ 				      req->base.complete, req->base.data);
+-	skcipher_request_set_crypt(skreq, dst, dst, cryptlen, req->iv);
++	skcipher_request_set_crypt(skreq, src, dst, cryptlen, req->iv);
+ 
+ 	return crypto_skcipher_decrypt(skreq);
+ }
+@@ -279,6 +284,7 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	unsigned int assoclen = req->assoclen;
+ 	unsigned int cryptlen = req->cryptlen;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u32 tmp[2];
+ 	int err;
+@@ -286,24 +292,28 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	if (assoclen < 8)
+ 		return -EINVAL;
+ 
+-	cryptlen -= authsize;
+-
+-	if (req->src != dst)
+-		memcpy_sglist(dst, req->src, assoclen + cryptlen);
++	if (!authsize)
++		goto tail;
+ 
++	cryptlen -= authsize;
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+ 
+-	if (!authsize)
+-		goto tail;
+-
+ 	/* Move high-order bits of sequence number to the end. */
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
+-
+-	sg_init_table(areq_ctx->dst, 2);
+-	dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	scatterwalk_map_and_copy(tmp, src, 0, 8, 0);
++	if (src == dst) {
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	} else {
++		scatterwalk_map_and_copy(tmp, dst, 0, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen - 4, 4, 1);
++
++		src = scatterwalk_ffwd(areq_ctx->src, src, 8);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++		memcpy_sglist(dst, src, assoclen + cryptlen - 8);
++		dst = req->dst;
++	}
+ 
+ 	ahash_request_set_tfm(ahreq, auth);
+ 	ahash_request_set_crypt(ahreq, dst, ohash, assoclen + cryptlen);

--- a/SOURCES/0023-crypto-doc-fix-kernel-doc-notation-in-chacha.c-and-a.patch
+++ b/SOURCES/0023-crypto-doc-fix-kernel-doc-notation-in-chacha.c-and-a.patch
@@ -1,0 +1,286 @@
+From efd365779b2317f79c3b1a0d71530e191f85a417 Mon Sep 17 00:00:00 2001
+From: Randy Dunlap <rdunlap@infradead.org>
+Date: Thu, 30 Apr 2026 00:01:19 -0700
+Subject: [PATCH] crypto: doc - fix kernel-doc notation in chacha.c and
+ af_alg.c
+
+commit b2a4411aca29ab7feb17c927d1d91d979361983c upstream.
+
+Fix function name in chacha.c kernel-doc comment to remove a warning.
+
+Convert af_alg.c to kernel-doc notation to eliminate many kernel-doc
+warnings.
+
+../lib/crypto/chacha.c:77: warning: expecting prototype for chacha_block(). Prototype was for chacha_block_generic() instead
+chacha.c:104: warning: Excess function parameter 'out' description in 'hchacha_block_generic'
+
+af_alg.c:498: warning: Function parameter or member 'sk' not described in 'af_alg_alloc_tsgl'
+../crypto/af_alg.c:539: warning: expecting prototype for aead_count_tsgl(). Prototype was for af_alg_count_tsgl() instead
+../crypto/af_alg.c:596: warning: expecting prototype for aead_pull_tsgl(). Prototype was for af_alg_pull_tsgl() instead
+af_alg.c:663: warning: Function parameter or member 'areq' not described in 'af_alg_free_areq_sgls'
+af_alg.c:700: warning: Function parameter or member 'sk' not described in 'af_alg_wait_for_wmem'
+af_alg.c:700: warning: Function parameter or member 'flags' not described in 'af_alg_wait_for_wmem'
+af_alg.c:731: warning: Function parameter or member 'sk' not described in 'af_alg_wmem_wakeup'
+af_alg.c:757: warning: Function parameter or member 'sk' not described in 'af_alg_wait_for_data'
+af_alg.c:757: warning: Function parameter or member 'flags' not described in 'af_alg_wait_for_data'
+af_alg.c:757: warning: Function parameter or member 'min' not described in 'af_alg_wait_for_data'
+af_alg.c:796: warning: Function parameter or member 'sk' not described in 'af_alg_data_wakeup'
+af_alg.c:832: warning: Function parameter or member 'sock' not described in 'af_alg_sendmsg'
+af_alg.c:832: warning: Function parameter or member 'msg' not described in 'af_alg_sendmsg'
+af_alg.c:832: warning: Function parameter or member 'size' not described in 'af_alg_sendmsg'
+af_alg.c:832: warning: Function parameter or member 'ivsize' not described in 'af_alg_sendmsg'
+af_alg.c:985: warning: Function parameter or member 'sock' not described in 'af_alg_sendpage'
+af_alg.c:985: warning: Function parameter or member 'page' not described in 'af_alg_sendpage'
+af_alg.c:985: warning: Function parameter or member 'offset' not described in 'af_alg_sendpage'
+af_alg.c:985: warning: Function parameter or member 'size' not described in 'af_alg_sendpage'
+af_alg.c:985: warning: Function parameter or member 'flags' not described in 'af_alg_sendpage'
+af_alg.c:1040: warning: Function parameter or member 'areq' not described in 'af_alg_free_resources'
+af_alg.c:1059: warning: Function parameter or member '_req' not described in 'af_alg_async_cb'
+af_alg.c:1059: warning: Function parameter or member 'err' not described in 'af_alg_async_cb'
+af_alg.c:1083: warning: Function parameter or member 'file' not described in 'af_alg_poll'
+af_alg.c:1083: warning: Function parameter or member 'sock' not described in 'af_alg_poll'
+af_alg.c:1083: warning: Function parameter or member 'wait' not described in 'af_alg_poll'
+af_alg.c:1114: warning: Function parameter or member 'sk' not described in 'af_alg_alloc_areq'
+af_alg.c:1114: warning: Function parameter or member 'areqlen' not described in 'af_alg_alloc_areq'
+af_alg.c:1146: warning: Function parameter or member 'sk' not described in 'af_alg_get_rsgl'
+af_alg.c:1146: warning: Function parameter or member 'msg' not described in 'af_alg_get_rsgl'
+af_alg.c:1146: warning: Function parameter or member 'flags' not described in 'af_alg_get_rsgl'
+af_alg.c:1146: warning: Function parameter or member 'areq' not described in 'af_alg_get_rsgl'
+af_alg.c:1146: warning: Function parameter or member 'maxsize' not described in 'af_alg_get_rsgl'
+af_alg.c:1146: warning: Function parameter or member 'outlen' not described in 'af_alg_get_rsgl'
+
+Signed-off-by: Randy Dunlap <rdunlap@infradead.org>
+Cc: Herbert Xu <herbert@gondor.apana.org.au>
+Cc: "David S. Miller" <davem@davemloft.net>
+Cc: linux-crypto@vger.kernel.org
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 8b3843b1e3bc36f57d14d770fe0286a9cbeb38b1)
+
+Conflicts in lib/chacha.20 due to missing 5fb8ef25803e ("crypto: chacha -
+move existing library code into lib/crypto") which moved a bunch of code
+from lib/chacha.c to lib/crypto/chacha.c but also renamed functions from
+hchacha_block to hchacha_block_generic.
+
+This backport is only here to support the backport of the Copy fail, so we
+can discard the code shuffling to chacha as it bears no impact.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+(cherry picked from commit 4b07d3e8555a283788fe31d1053fde4821a5f4eb)
+---
+ crypto/af_alg.c | 94 ++++++++++++++++++++++++++++---------------------
+ 1 file changed, 53 insertions(+), 41 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index a11b3d22ef9a..1b947f827ac9 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -486,8 +486,8 @@ EXPORT_SYMBOL_GPL(af_alg_cmsg_send);
+ /**
+  * af_alg_alloc_tsgl - allocate the TX SGL
+  *
+- * @sk socket of connection to user space
+- * @return: 0 upon success, < 0 upon error
++ * @sk: socket of connection to user space
++ * Return: 0 upon success, < 0 upon error
+  */
+ int af_alg_alloc_tsgl(struct sock *sk)
+ {
+@@ -523,15 +523,15 @@ int af_alg_alloc_tsgl(struct sock *sk)
+ EXPORT_SYMBOL_GPL(af_alg_alloc_tsgl);
+ 
+ /**
+- * aead_count_tsgl - Count number of TX SG entries
++ * af_alg_count_tsgl - Count number of TX SG entries
+  *
+  * The counting starts from the beginning of the SGL to @bytes. If
+- * an offset is provided, the counting of the SG entries starts at the offset.
++ * an @offset is provided, the counting of the SG entries starts at the @offset.
+  *
+- * @sk socket of connection to user space
+- * @bytes Count the number of SG entries holding given number of bytes.
+- * @offset Start the counting of SG entries from the given offset.
+- * @return Number of TX SG entries found given the constraints
++ * @sk: socket of connection to user space
++ * @bytes: Count the number of SG entries holding given number of bytes.
++ * @offset: Start the counting of SG entries from the given offset.
++ * Return: Number of TX SG entries found given the constraints
+  */
+ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ {
+@@ -575,19 +575,19 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+ 
+ /**
+- * aead_pull_tsgl - Release the specified buffers from TX SGL
++ * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+- * If @dst is non-null, reassign the pages to dst. The caller must release
++ * If @dst is non-null, reassign the pages to @dst. The caller must release
+  * the pages. If @dst_offset is given only reassign the pages to @dst starting
+  * at the @dst_offset (byte). The caller must ensure that @dst is large
+  * enough (e.g. by using af_alg_count_tsgl with the same offset).
+  *
+- * @sk socket of connection to user space
+- * @used Number of bytes to pull from TX SGL
+- * @dst If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+- *	caller must release the buffers in dst.
+- * @dst_offset Reassign the TX SGL from given offset. All buffers before
+- *	       reaching the offset is released.
++ * @sk: socket of connection to user space
++ * @used: Number of bytes to pull from TX SGL
++ * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
++ *	 caller must release the buffers in dst.
++ * @dst_offset: Reassign the TX SGL from given offset. All buffers before
++ *	        reaching the offset is released.
+  */
+ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 		      size_t dst_offset)
+@@ -656,7 +656,7 @@ EXPORT_SYMBOL_GPL(af_alg_pull_tsgl);
+ /**
+  * af_alg_free_areq_sgls - Release TX and RX SGLs of the request
+  *
+- * @areq Request holding the TX and RX SGL
++ * @areq: Request holding the TX and RX SGL
+  */
+ void af_alg_free_areq_sgls(struct af_alg_async_req *areq)
+ {
+@@ -692,9 +692,9 @@ EXPORT_SYMBOL_GPL(af_alg_free_areq_sgls);
+ /**
+  * af_alg_wait_for_wmem - wait for availability of writable memory
+  *
+- * @sk socket of connection to user space
+- * @flags If MSG_DONTWAIT is set, then only report if function would sleep
+- * @return 0 when writable memory is available, < 0 upon error
++ * @sk: socket of connection to user space
++ * @flags: If MSG_DONTWAIT is set, then only report if function would sleep
++ * Return: 0 when writable memory is available, < 0 upon error
+  */
+ int af_alg_wait_for_wmem(struct sock *sk, unsigned int flags)
+ {
+@@ -726,7 +726,7 @@ EXPORT_SYMBOL_GPL(af_alg_wait_for_wmem);
+ /**
+  * af_alg_wmem_wakeup - wakeup caller when writable memory is available
+  *
+- * @sk socket of connection to user space
++ * @sk: socket of connection to user space
+  */
+ void af_alg_wmem_wakeup(struct sock *sk)
+ {
+@@ -749,10 +749,10 @@ EXPORT_SYMBOL_GPL(af_alg_wmem_wakeup);
+ /**
+  * af_alg_wait_for_data - wait for availability of TX data
+  *
+- * @sk socket of connection to user space
+- * @flags If MSG_DONTWAIT is set, then only report if function would sleep
+- * @min Set to minimum request size if partial requests are allowed.
+- * @return 0 when writable memory is available, < 0 upon error
++ * @sk: socket of connection to user space
++ * @flags: If MSG_DONTWAIT is set, then only report if function would sleep
++ * @min: Set to minimum request size if partial requests are allowed.
++ * Return: 0 when writable memory is available, < 0 upon error
+  */
+ int af_alg_wait_for_data_with_min(struct sock *sk, unsigned flags, unsigned min)
+ {
+@@ -797,7 +797,7 @@ EXPORT_SYMBOL_GPL(af_alg_wait_for_data);
+ /**
+  * af_alg_data_wakeup - wakeup caller when new data can be sent to kernel
+  *
+- * @sk socket of connection to user space
++ * @sk: socket of connection to user space
+  */
+ 
+ void af_alg_data_wakeup(struct sock *sk)
+@@ -829,12 +829,12 @@ EXPORT_SYMBOL_GPL(af_alg_data_wakeup);
+  *
+  * In addition, the ctx is filled with the information sent via CMSG.
+  *
+- * @sock socket of connection to user space
+- * @msg message from user space
+- * @size size of message from user space
+- * @ivsize the size of the IV for the cipher operation to verify that the
++ * @sock: socket of connection to user space
++ * @msg: message from user space
++ * @size: size of message from user space
++ * @ivsize: the size of the IV for the cipher operation to verify that the
+  *	   user-space-provided IV has the right size
+- * @return the number of copied data upon success, < 0 upon error
++ * Return: the number of copied data upon success, < 0 upon error
+  */
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+ 		   unsigned int ivsize)
+@@ -993,6 +993,11 @@ EXPORT_SYMBOL_GPL(af_alg_sendmsg);
+ 
+ /**
+  * af_alg_sendpage - sendpage system call handler
++ * @sock: socket of connection to user space to write to
++ * @page: data to send
++ * @offset: offset into page to begin sending
++ * @size: length of data
++ * @flags: message send/receive flags
+  *
+  * This is a generic implementation of sendpage to fill ctx->tsgl_list.
+  */
+@@ -1051,6 +1056,7 @@ EXPORT_SYMBOL_GPL(af_alg_sendpage);
+ 
+ /**
+  * af_alg_free_resources - release resources required for crypto request
++ * @areq: Request holding the TX and RX SGL
+  */
+ void af_alg_free_resources(struct af_alg_async_req *areq)
+ {
+@@ -1067,6 +1073,9 @@ EXPORT_SYMBOL_GPL(af_alg_free_resources);
+ 
+ /**
+  * af_alg_async_cb - AIO callback handler
++ * @_req: async request info
++ * @err: if non-zero, error result to be returned via ki_complete();
++ *       otherwise return the AIO output length via ki_complete().
+  *
+  * This handler cleans up the struct af_alg_async_req upon completion of the
+  * AIO operation.
+@@ -1093,6 +1102,9 @@ EXPORT_SYMBOL_GPL(af_alg_async_cb);
+ 
+ /**
+  * af_alg_poll - poll system call handler
++ * @file: file pointer
++ * @sock: socket to poll
++ * @wait: poll_table
+  */
+ __poll_t af_alg_poll(struct file *file, struct socket *sock,
+ 			 poll_table *wait)
+@@ -1118,9 +1130,9 @@ EXPORT_SYMBOL_GPL(af_alg_poll);
+ /**
+  * af_alg_alloc_areq - allocate struct af_alg_async_req
+  *
+- * @sk socket of connection to user space
+- * @areqlen size of struct af_alg_async_req + crypto_*_reqsize
+- * @return allocated data structure or ERR_PTR upon error
++ * @sk: socket of connection to user space
++ * @areqlen: size of struct af_alg_async_req + crypto_*_reqsize
++ * Return: allocated data structure or ERR_PTR upon error
+  */
+ struct af_alg_async_req *af_alg_alloc_areq(struct sock *sk,
+ 					   unsigned int areqlen)
+@@ -1153,13 +1165,13 @@ EXPORT_SYMBOL_GPL(af_alg_alloc_areq);
+  * af_alg_get_rsgl - create the RX SGL for the output data from the crypto
+  *		     operation
+  *
+- * @sk socket of connection to user space
+- * @msg user space message
+- * @flags flags used to invoke recvmsg with
+- * @areq instance of the cryptographic request that will hold the RX SGL
+- * @maxsize maximum number of bytes to be pulled from user space
+- * @outlen number of bytes in the RX SGL
+- * @return 0 on success, < 0 upon error
++ * @sk: socket of connection to user space
++ * @msg: user space message
++ * @flags: flags used to invoke recvmsg with
++ * @areq: instance of the cryptographic request that will hold the RX SGL
++ * @maxsize: maximum number of bytes to be pulled from user space
++ * @outlen: number of bytes in the RX SGL
++ * Return: 0 on success, < 0 upon error
+  */
+ int af_alg_get_rsgl(struct sock *sk, struct msghdr *msg, int flags,
+ 		    struct af_alg_async_req *areq, size_t maxsize,

--- a/SOURCES/0024-crypto-algif_aead-use-memcpy_sglist-instead-of-null-.patch
+++ b/SOURCES/0024-crypto-algif_aead-use-memcpy_sglist-instead-of-null-.patch
@@ -1,0 +1,250 @@
+From 2c507e389e3cba7b657af0a607f7bbda7eb6b773 Mon Sep 17 00:00:00 2001
+From: Eric Biggers <ebiggers@google.com>
+Date: Thu, 30 Apr 2026 00:01:21 -0700
+Subject: [PATCH] crypto: algif_aead - use memcpy_sglist() instead of null
+ skcipher
+
+commit f2804d0eee8ddd57aa79d0b82872b74c21e1b69b upstream.
+
+For copying data between two scatterlists, just use memcpy_sglist()
+instead of the so-called "null skcipher".  This is much simpler.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 488f9c3ab90e333ad5185d9236c1e10898acf041)
+
+Only conflict was in crypto/Kconfig due to missing b95bba5d0114 ("crypto:
+skcipher - rename the crypto_blkcipher module and kconfig option"), which
+only renamed CRYPTO_BLKCIPHER to CRYPTO_SKCIPHER.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/Kconfig      |  1 -
+ crypto/algif_aead.c | 98 ++++++++-------------------------------------
+ 2 files changed, 17 insertions(+), 82 deletions(-)
+
+diff --git a/crypto/Kconfig b/crypto/Kconfig
+index 34926ae336c3..27ad7db8ea68 100644
+--- a/crypto/Kconfig
++++ b/crypto/Kconfig
+@@ -1854,7 +1854,6 @@ config CRYPTO_USER_API_AEAD
+ 	depends on NET
+ 	select CRYPTO_AEAD
+ 	select CRYPTO_BLKCIPHER
+-	select CRYPTO_NULL
+ 	select CRYPTO_USER_API
+ 	help
+ 	  This option enables the user-spaces interface for AEAD
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index c9212563e875..e5eb5f1f235d 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -31,7 +31,6 @@
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+ #include <crypto/skcipher.h>
+-#include <crypto/null.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -40,19 +39,13 @@
+ #include <linux/net.h>
+ #include <net/sock.h>
+ 
+-struct aead_tfm {
+-	struct crypto_aead *aead;
+-	struct crypto_sync_skcipher *null_tfm;
+-};
+-
+ static inline bool aead_sufficient_data(struct sock *sk)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
+ 
+ 	/*
+@@ -68,27 +61,12 @@ static int aead_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 
+ 	return af_alg_sendmsg(sock, msg, size, ivsize);
+ }
+ 
+-static int crypto_aead_copy_sgl(struct crypto_sync_skcipher *null_tfm,
+-				struct scatterlist *src,
+-				struct scatterlist *dst, unsigned int len)
+-{
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, null_tfm);
+-
+-	skcipher_request_set_sync_tfm(skreq, null_tfm);
+-	skcipher_request_set_callback(skreq, CRYPTO_TFM_REQ_MAY_SLEEP,
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, src, dst, len, NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 			 size_t ignored, int flags)
+ {
+@@ -97,9 +75,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
+-	struct crypto_sync_skcipher *null_tfm = aeadc->null_tfm;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int i, as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct af_alg_tsgl *tsgl, *tmp;
+@@ -227,10 +203,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		 *	    v	   v
+ 		 * RX SGL: AAD || PT || Tag
+ 		 */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sg, processed);
+-		if (err)
+-			goto free;
++		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, processed);
+ 		af_alg_pull_tsgl(sk, processed, NULL, 0);
+ 	} else {
+ 		/*
+@@ -244,11 +217,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		 * RX SGL: AAD || CT ----+
+ 		 */
+ 
+-		 /* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sg, outlen);
+-		if (err)
+-			goto free;
++		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
++		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, outlen);
+ 
+ 		/* Create TX SGL for tag and chain it to RX SGL. */
+ 		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+@@ -384,7 +354,7 @@ static int aead_check_key(struct socket *sock)
+ 	int err = 0;
+ 	struct sock *psk;
+ 	struct alg_sock *pask;
+-	struct aead_tfm *tfm;
++	struct crypto_aead *tfm;
+ 	struct sock *sk = sock->sk;
+ 	struct alg_sock *ask = alg_sk(sk);
+ 
+@@ -398,7 +368,7 @@ static int aead_check_key(struct socket *sock)
+ 
+ 	err = -ENOKEY;
+ 	lock_sock_nested(psk, SINGLE_DEPTH_NESTING);
+-	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
++	if (crypto_aead_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		goto unlock;
+ 
+ 	atomic_dec(&pask->nokey_refcnt);
+@@ -474,54 +444,22 @@ static struct proto_ops algif_aead_ops_nokey = {
+ 
+ static void *aead_bind(const char *name, u32 type, u32 mask)
+ {
+-	struct aead_tfm *tfm;
+-	struct crypto_aead *aead;
+-	struct crypto_sync_skcipher *null_tfm;
+-
+-	tfm = kzalloc(sizeof(*tfm), GFP_KERNEL);
+-	if (!tfm)
+-		return ERR_PTR(-ENOMEM);
+-
+-	aead = crypto_alloc_aead(name, type, mask);
+-	if (IS_ERR(aead)) {
+-		kfree(tfm);
+-		return ERR_CAST(aead);
+-	}
+-
+-	null_tfm = crypto_get_default_null_skcipher();
+-	if (IS_ERR(null_tfm)) {
+-		crypto_free_aead(aead);
+-		kfree(tfm);
+-		return ERR_CAST(null_tfm);
+-	}
+-
+-	tfm->aead = aead;
+-	tfm->null_tfm = null_tfm;
+-
+-	return tfm;
++	return crypto_alloc_aead(name, type, mask);
+ }
+ 
+ static void aead_release(void *private)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	crypto_free_aead(tfm->aead);
+-	crypto_put_default_null_skcipher();
+-	kfree(tfm);
++	crypto_free_aead(private);
+ }
+ 
+ static int aead_setauthsize(void *private, unsigned int authsize)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	return crypto_aead_setauthsize(tfm->aead, authsize);
++	return crypto_aead_setauthsize(private, authsize);
+ }
+ 
+ static int aead_setkey(void *private, const u8 *key, unsigned int keylen)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	return crypto_aead_setkey(tfm->aead, key, keylen);
++	return crypto_aead_setkey(private, key, keylen);
+ }
+ 
+ static void aead_sock_destruct(struct sock *sk)
+@@ -530,8 +468,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+ 	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
+@@ -544,10 +481,9 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ {
+ 	struct af_alg_ctx *ctx;
+ 	struct alg_sock *ask = alg_sk(sk);
+-	struct aead_tfm *tfm = private;
+-	struct crypto_aead *aead = tfm->aead;
++	struct crypto_aead *tfm = private;
+ 	unsigned int len = sizeof(*ctx);
+-	unsigned int ivlen = crypto_aead_ivsize(aead);
++	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+ 	ctx = sock_kmalloc(sk, len, GFP_KERNEL);
+ 	if (!ctx)
+@@ -574,9 +510,9 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ 
+ static int aead_accept_parent(void *private, struct sock *sk)
+ {
+-	struct aead_tfm *tfm = private;
++	struct crypto_aead *tfm = private;
+ 
+-	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
++	if (crypto_aead_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		return -ENOKEY;
+ 
+ 	return aead_accept_parent_nokey(private, sk);

--- a/SOURCES/0025-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+++ b/SOURCES/0025-crypto-algif_aead-Revert-to-operating-out-of-place.patch
@@ -1,0 +1,326 @@
+From 9b6ccbdf2b337aca640bcaa75b783e8ba764f862 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 30 Apr 2026 00:01:22 -0700
+Subject: [PATCH] crypto: algif_aead - Revert to operating out-of-place
+
+commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 upstream.
+
+This mostly reverts commit 72548b093ee3 except for the copying of
+the associated data.
+
+There is no benefit in operating in-place in algif_aead since the
+source and destination come from different mappings.  Get rid of
+all the complexity added for in-place operation and just copy the
+AD directly.
+
+Fixes: 72548b093ee3 ("crypto: algif_aead - copy AAD from src to dst")
+Reported-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 893d22e0135fa394db81df88697fba6032747667)
+
+Context conflicts in include/crypto/if_alg.h due to missing
+466e0759269d ("crypto: af_alg - make some functions static"), which didn't
+bring any meaningful changes a part from removing some function exports
+which would break our kABI.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 49 +++++---------------
+ crypto/algif_aead.c     | 99 ++++++++---------------------------------
+ crypto/algif_skcipher.c |  6 +--
+ include/crypto/if_alg.h |  5 +--
+ 4 files changed, 34 insertions(+), 125 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 1b947f827ac9..89f97dace4d0 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -525,15 +525,13 @@ EXPORT_SYMBOL_GPL(af_alg_alloc_tsgl);
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -548,25 +546,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -578,19 +562,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -615,18 +594,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index e5eb5f1f235d..e8aaf1380e4c 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -30,7 +30,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -76,9 +75,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -158,23 +156,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -183,75 +182,15 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sg;
+ 
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, processed);
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, outlen);
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-
+-			sg_unmark_end(sgl_prev->sg + sgl_prev->npages - 1);
+-			sg_chain(sgl_prev->sg, sgl_prev->npages + 1,
+-				 areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	memcpy_sglist(rsgl_src, tsgl_src, ctx->aead_assoclen);
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sg, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -471,7 +410,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 7ea273069a6a..fc7e643c00f0 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -93,7 +93,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -104,7 +104,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -321,7 +321,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index e178090808c6..f7fd8d960f4e 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -270,9 +270,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ }
+ 
+ int af_alg_alloc_tsgl(struct sock *sk);
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
+ void af_alg_free_areq_sgls(struct af_alg_async_req *areq);
+ int af_alg_wait_for_wmem(struct sock *sk, unsigned int flags);
+ void af_alg_wmem_wakeup(struct sock *sk);

--- a/SOURCES/0026-kabi-crypto-algif_aead-Revert-to-operating-out-of-pl.patch
+++ b/SOURCES/0026-kabi-crypto-algif_aead-Revert-to-operating-out-of-pl.patch
@@ -1,0 +1,127 @@
+From c58171d3b402a60785af37672ff54e4a10b56eb7 Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Mon, 4 May 2026 14:37:11 +0200
+Subject: [PATCH] !kabi crypto: algif_aead - Revert to operating out-of-place
+
+Instead of removing the offset/dst_offset from the exported functions,
+leave them in place to avoid kABI changes.
+
+Note that none of our binary kernel modules are using this ABI.
+
+Fixes: 727dcb837787 ("crypto: algif_aead - Revert to operating out-of-place")
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c         | 10 ++++++++--
+ crypto/algif_aead.c     |  6 +++---
+ crypto/algif_skcipher.c |  6 +++---
+ include/crypto/if_alg.h |  4 ++--
+ 4 files changed, 16 insertions(+), 10 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 89f97dace4d0..e0b3d561bfdb 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -529,9 +529,12 @@ EXPORT_SYMBOL_GPL(af_alg_alloc_tsgl);
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
++ * @offset: Ignored, kept for kABI invariance to fix CopyFail with backport
++ * of 893d22e0135f ("crypto: algif_aead - Revert to operating
++ * out-of-place")
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -568,8 +571,11 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
++ * @dst_offset: Ignored, kept for kABI invariance to fix CopyFail with backport
++ * of 893d22e0135f ("crypto: algif_aead - Revert to operating
++ * out-of-place")
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst, size_t dst_offset)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index e8aaf1380e4c..53f12c42a842 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -161,7 +161,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * SG entries from the global TX SGL.
+ 	 */
+ 	processed = used + ctx->aead_assoclen;
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed, 0);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -172,7 +172,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl, 0);
+ 	tsgl_src = areq->tsgl;
+ 
+ 	/*
+@@ -410,7 +410,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL);
++	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index fc7e643c00f0..7ea273069a6a 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -93,7 +93,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -104,7 +104,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl);
++	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -321,7 +321,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL);
++	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index f7fd8d960f4e..5cc88eb98826 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -270,8 +270,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ }
+ 
+ int af_alg_alloc_tsgl(struct sock *sk);
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst, size_t offset);
+ void af_alg_free_areq_sgls(struct af_alg_async_req *areq);
+ int af_alg_wait_for_wmem(struct sock *sk, unsigned int flags);
+ void af_alg_wmem_wakeup(struct sock *sk);

--- a/SOURCES/0027-crypto-algif_aead-snapshot-IV-for-async-AEAD-request.patch
+++ b/SOURCES/0027-crypto-algif_aead-snapshot-IV-for-async-AEAD-request.patch
@@ -1,0 +1,76 @@
+From 44e392e4d4ab88b6b6272a2da1784dbe3e331a3a Mon Sep 17 00:00:00 2001
+From: Douya Le <ldy3087146292@gmail.com>
+Date: Thu, 30 Apr 2026 00:01:23 -0700
+Subject: [PATCH] crypto: algif_aead - snapshot IV for async AEAD requests
+
+commit 5aa58c3a572b3e3b6c786953339f7978b845cc52 upstream.
+
+AF_ALG AEAD AIO requests currently use the socket-wide IV buffer during
+request processing.  For async requests, later socket activity can
+update that shared state before the original request has fully
+completed, which can lead to inconsistent IV handling.
+
+Snapshot the IV into per-request storage when preparing the AEAD
+request, so in-flight operations no longer depend on mutable socket
+state.
+
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Cc: stable@kernel.org
+Reported-by: Yuan Tan <yuantan098@gmail.com>
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Reported-by: Xin Liu <bird@lzu.edu.cn>
+Co-developed-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Signed-off-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Tested-by: Yucheng Lu <kanolyc@gmail.com>
+Signed-off-by: Douya Le <ldy3087146292@gmail.com>
+Signed-off-by: Ren Wei <n05ec@lzu.edu.cn>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 08ea39a556ecd39b33c2b4888861001c6706a62e)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_aead.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index 53f12c42a842..e636c9f18f1d 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -76,8 +76,10 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
++	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
++	void *iv;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+ 	size_t outlen = 0;		/* [out] RX bufs produced by kernel */
+@@ -129,10 +131,14 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Allocate cipher request for current operation. */
+ 	areq = af_alg_alloc_areq(sk, sizeof(struct af_alg_async_req) +
+-				     crypto_aead_reqsize(tfm));
++				     crypto_aead_reqsize(tfm) + ivsize);
+ 	if (IS_ERR(areq))
+ 		return PTR_ERR(areq);
+ 
++	iv = (u8 *)aead_request_ctx(&areq->cra_u.aead_req) +
++	     crypto_aead_reqsize(tfm);
++	memcpy(iv, ctx->iv, ivsize);
++
+ 	/* convert iovecs of output buffers into RX SGL */
+ 	err = af_alg_get_rsgl(sk, msg, flags, areq, outlen, &usedpages);
+ 	if (err)
+@@ -191,7 +197,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Initialize the crypto operation */
+ 	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+-			       areq->first_rsgl.sgl.sg, used, ctx->iv);
++			       areq->first_rsgl.sgl.sg, used, iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+ 

--- a/SOURCES/0028-crypto-scatterwalk-Backport-memcpy_sglist.patch
+++ b/SOURCES/0028-crypto-scatterwalk-Backport-memcpy_sglist.patch
@@ -1,0 +1,182 @@
+From e847542d8728a60634fb97df5f5b09a7cd3c66f8 Mon Sep 17 00:00:00 2001
+From: Eric Biggers <ebiggers@kernel.org>
+Date: Thu, 30 Apr 2026 00:01:20 -0700
+Subject: [PATCH] crypto: scatterwalk - Backport memcpy_sglist()
+
+This backports the current implementation of memcpy_sglist() from
+upstream commit 4dffc9bbffb9ccfcda730d899c97c553599e7ca8.
+
+This function was rewritten twice.  The earlier implementations had many
+prerequisite commits, while the latest implementation is standalone.
+It's much easier to just backport the latest code directly.
+
+[5.10: replaced kmap_local and memcpy_page]
+
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 534b7f208c6019df5aacc249c6667845b1cc1dd3)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/scatterwalk.c         | 98 ++++++++++++++++++++++++++++++++++++
+ include/crypto/scatterwalk.h | 32 ++++++++++++
+ 2 files changed, 130 insertions(+)
+
+diff --git a/crypto/scatterwalk.c b/crypto/scatterwalk.c
+index d0b92c1cd6e9..7b2be8007d02 100644
+--- a/crypto/scatterwalk.c
++++ b/crypto/scatterwalk.c
+@@ -74,6 +74,104 @@ void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+ }
+ EXPORT_SYMBOL_GPL(scatterwalk_map_and_copy);
+ 
++/**
++ * memcpy_sglist() - Copy data from one scatterlist to another
++ * @dst: The destination scatterlist.  Can be NULL if @nbytes == 0.
++ * @src: The source scatterlist.  Can be NULL if @nbytes == 0.
++ * @nbytes: Number of bytes to copy
++ *
++ * The scatterlists can describe exactly the same memory, in which case this
++ * function is a no-op.  No other overlaps are supported.
++ *
++ * Context: Any context
++ */
++void memcpy_sglist(struct scatterlist *dst, struct scatterlist *src,
++		   unsigned int nbytes)
++{
++	unsigned int src_offset, dst_offset;
++
++	if (unlikely(nbytes == 0)) /* in case src and/or dst is NULL */
++		return;
++
++	src_offset = src->offset;
++	dst_offset = dst->offset;
++	for (;;) {
++		/* Compute the length to copy this step. */
++		unsigned int len = min3(src->offset + src->length - src_offset,
++					dst->offset + dst->length - dst_offset,
++					nbytes);
++		struct page *src_page = sg_page(src);
++		struct page *dst_page = sg_page(dst);
++		const void *src_virt;
++		void *dst_virt;
++
++		if (IS_ENABLED(CONFIG_HIGHMEM)) {
++			/* HIGHMEM: we may have to actually map the pages. */
++			const unsigned int src_oip = offset_in_page(src_offset);
++			const unsigned int dst_oip = offset_in_page(dst_offset);
++			const unsigned int limit = PAGE_SIZE;
++
++			/* Further limit len to not cross a page boundary. */
++			len = min3(len, limit - src_oip, limit - dst_oip);
++
++			/* Compute the source and destination pages. */
++			src_page += src_offset / PAGE_SIZE;
++			dst_page += dst_offset / PAGE_SIZE;
++
++			if (src_page != dst_page) {
++				/* Copy between different pages. */
++				dst_virt = kmap_atomic(dst_page);
++				src_virt = kmap_atomic(src_page);
++				memcpy(dst_virt + dst_oip, src_virt + src_oip,
++				       len);
++				kunmap_atomic((void *)src_virt);
++				kunmap_atomic(dst_virt);
++				flush_dcache_page(dst_page);
++			} else if (src_oip != dst_oip) {
++				/* Copy between different parts of same page. */
++				dst_virt = kmap_atomic(dst_page);
++				memcpy(dst_virt + dst_oip, dst_virt + src_oip,
++				       len);
++				kunmap_atomic(dst_virt);
++				flush_dcache_page(dst_page);
++			} /* Else, it's the same memory.  No action needed. */
++		} else {
++			/*
++			 * !HIGHMEM: no mapping needed.  Just work in the linear
++			 * buffer of each sg entry.  Note that we can cross page
++			 * boundaries, as they are not significant in this case.
++			 */
++			src_virt = page_address(src_page) + src_offset;
++			dst_virt = page_address(dst_page) + dst_offset;
++			if (src_virt != dst_virt) {
++				memcpy(dst_virt, src_virt, len);
++				if (ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE)
++					__scatterwalk_flush_dcache_pages(
++						dst_page, dst_offset, len);
++			} /* Else, it's the same memory.  No action needed. */
++		}
++		nbytes -= len;
++		if (nbytes == 0) /* No more to copy? */
++			break;
++
++		/*
++		 * There's more to copy.  Advance the offsets by the length
++		 * copied this step, and advance the sg entries as needed.
++		 */
++		src_offset += len;
++		if (src_offset >= src->offset + src->length) {
++			src = sg_next(src);
++			src_offset = src->offset;
++		}
++		dst_offset += len;
++		if (dst_offset >= dst->offset + dst->length) {
++			dst = sg_next(dst);
++			dst_offset = dst->offset;
++		}
++	}
++}
++EXPORT_SYMBOL_GPL(memcpy_sglist);
++
+ struct scatterlist *scatterwalk_ffwd(struct scatterlist dst[2],
+ 				     struct scatterlist *src,
+ 				     unsigned int len)
+diff --git a/include/crypto/scatterwalk.h b/include/crypto/scatterwalk.h
+index a66c127a20ed..0d79e74d081c 100644
+--- a/include/crypto/scatterwalk.h
++++ b/include/crypto/scatterwalk.h
+@@ -98,6 +98,35 @@ static inline void scatterwalk_pagedone(struct scatter_walk *walk, int out,
+ 		scatterwalk_start(walk, sg_next(walk->sg));
+ }
+ 
++/*
++ * Flush the dcache of any pages that overlap the region
++ * [offset, offset + nbytes) relative to base_page.
++ *
++ * This should be called only when ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE, to ensure
++ * that all relevant code (including the call to sg_page() in the caller, if
++ * applicable) gets fully optimized out when !ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE.
++ */
++static inline void __scatterwalk_flush_dcache_pages(struct page *base_page,
++						    unsigned int offset,
++						    unsigned int nbytes)
++{
++	unsigned int num_pages;
++	unsigned int i;
++
++	base_page += offset / PAGE_SIZE;
++	offset %= PAGE_SIZE;
++
++	/*
++	 * This is an overflow-safe version of
++	 * num_pages = DIV_ROUND_UP(offset + nbytes, PAGE_SIZE).
++	 */
++	num_pages = nbytes / PAGE_SIZE;
++	num_pages += DIV_ROUND_UP(offset + (nbytes % PAGE_SIZE), PAGE_SIZE);
++
++	for (i = 0; i < num_pages; i++)
++		flush_dcache_page(base_page + i);
++}
++
+ static inline void scatterwalk_done(struct scatter_walk *walk, int out,
+ 				    int more)
+ {
+@@ -110,6 +139,9 @@ void scatterwalk_copychunks(void *buf, struct scatter_walk *walk,
+ 			    size_t nbytes, int out);
+ void *scatterwalk_map(struct scatter_walk *walk);
+ 
++void memcpy_sglist(struct scatterlist *dst, struct scatterlist *src,
++		   unsigned int nbytes);
++
+ void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+ 			      unsigned int start, unsigned int nbytes, int out);
+ 

--- a/SOURCES/0029-crypto-algif_aead-Fix-minimum-RX-size-check-for-decr.patch
+++ b/SOURCES/0029-crypto-algif_aead-Fix-minimum-RX-size-check-for-decr.patch
@@ -1,0 +1,36 @@
+From e171fea07f5f1b09c95ffb10e647c75632445a79 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 30 Apr 2026 00:01:28 -0700
+Subject: [PATCH] crypto: algif_aead - Fix minimum RX size check for decryption
+
+commit 3d14bd48e3a77091cbce637a12c2ae31b4a1687c upstream.
+
+The check for the minimum receive buffer size did not take the
+tag size into account during decryption.  Fix this by adding the
+required extra length.
+
+Reported-by: syzbot+aa11561819dc42ebbc7c@syzkaller.appspotmail.com
+Reported-by: Daniel Pouzzner <douzzer@mega.nu>
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 74a66fdb5282d89e348b00c42cfca3a936946d94)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/algif_aead.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index e636c9f18f1d..60642cc0a47e 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -154,7 +154,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	if (usedpages < outlen) {
+ 		size_t less = outlen - usedpages;
+ 
+-		if (used < less) {
++		if (used < less + (ctx->enc ? 0 : as)) {
+ 			err = -EINVAL;
+ 			goto free;
+ 		}

--- a/SOURCES/0030-crypto-af_alg-Fix-page-reassignment-overflow-in-af_a.patch
+++ b/SOURCES/0030-crypto-af_alg-Fix-page-reassignment-overflow-in-af_a.patch
@@ -1,0 +1,43 @@
+From 97c35a29590229f69d79495fb6277ef537b6ffe6 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 30 Apr 2026 00:01:27 -0700
+Subject: [PATCH] crypto: af_alg - Fix page reassignment overflow in
+ af_alg_pull_tsgl
+
+commit 31d00156e50ecad37f2cb6cbf04aaa9a260505ef upstream.
+
+When page reassignment was added to af_alg_pull_tsgl the original
+loop wasn't updated so it may try to reassign one more page than
+necessary.
+
+Add the check to the reassignment so that this does not happen.
+
+Also update the comment which still refers to the obsolete offset
+argument.
+
+Reported-by: syzbot+d23888375c2737c17ba5@syzkaller.appspotmail.com
+Fixes: e870456d8e7c ("crypto: algif_skcipher - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit fa48d3ea9cdbfb28c1fd6756c6c5cd01351aa51e)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/af_alg.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index e0b3d561bfdb..4e9631bdcfb3 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -599,8 +599,8 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst, siz
+ 			 * Assumption: caller created af_alg_count_tsgl(len)
+ 			 * SG entries in dst.
+ 			 */
+-			if (dst) {
+-				/* reassign page to dst after offset */
++			if (dst && plen) {
++				/* reassign page to dst */
+ 				get_page(page);
+ 				sg_set_page(dst + j, page, plen, sg[i].offset);
+ 				j++;

--- a/SOURCES/0031-crypto-authencesn-Fix-src-offset-when-decrypting-in-.patch
+++ b/SOURCES/0031-crypto-authencesn-Fix-src-offset-when-decrypting-in-.patch
@@ -1,0 +1,39 @@
+From 2fa191c163e39c8f67510b791093cba07eae6bdb Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 30 Apr 2026 00:01:26 -0700
+Subject: [PATCH] crypto: authencesn - Fix src offset when decrypting in-place
+
+commit 1f48ad3b19a9dfc947868edda0bb8e48e5b5a8fa upstream.
+
+The src SG list offset wasn't set properly when decrypting in-place,
+fix it.
+
+Reported-by: Wolfgang Walter <linux@stwm.de>
+Fixes: e02494114ebf ("crypto: authencesn - Do not place hiseq at end of dst for out-of-place decryption")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 88881da57e60ef796c59bf53bb34221c960ec707)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ crypto/authencesn.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+index d3731ac1d156..1a7a9e3652e3 100644
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -250,9 +250,11 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 
+ decrypt:
+ 
+-	if (src != dst)
+-		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
++	if (req->src == req->dst)
++		src = dst;
++	else
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,

--- a/SOURCES/0032-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags.patch
+++ b/SOURCES/0032-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags.patch
@@ -1,0 +1,96 @@
+From 46120029c283dbcceb976971483baeb54d80f987 Mon Sep 17 00:00:00 2001
+From: Kuan-Ting Chen <h3xrabbit@gmail.com>
+Date: Mon, 4 May 2026 23:27:12 +0800
+Subject: [PATCH] xfrm: esp: avoid in-place decrypt on shared skb frags
+
+commit f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4 upstream.
+
+MSG_SPLICE_PAGES can attach pages from a pipe directly to an skb. TCP
+marks such skbs with SKBFL_SHARED_FRAG after skb_splice_from_iter(),
+so later paths that may modify packet data can first make a private
+copy. The IPv4/IPv6 datagram append paths did not set this flag when
+splicing pages into UDP skbs.
+
+That leaves an ESP-in-UDP packet made from shared pipe pages looking
+like an ordinary uncloned nonlinear skb. ESP input then takes the no-COW
+fast path for uncloned skbs without a frag_list and decrypts in place
+over data that is not owned privately by the skb.
+
+Mark IPv4/IPv6 datagram splice frags with SKBFL_SHARED_FRAG, matching
+TCP. Also make ESP input fall back to skb_cow_data() when the flag is
+present, so ESP does not decrypt externally backed frags in place.
+Private nonlinear skb frags still use the existing fast path.
+
+This intentionally does not change ESP output. In esp_output_head(),
+the path that appends the ESP trailer to existing skb tailroom without
+calling skb_cow_data() is not reachable for nonlinear skbs:
+skb_tailroom() returns zero when skb->data_len is nonzero, while ESP
+tailen is positive. Thus ESP output will either use the separate
+destination-frag path or fall back to skb_cow_data().
+
+Fixes: cac2661c53f3 ("esp4: Avoid skb_cow_data whenever possible")
+Fixes: 03e2a30f6a27 ("esp6: Avoid skb_cow_data whenever possible")
+Fixes: 7da0dde68486 ("ip, udp: Support MSG_SPLICE_PAGES")
+Fixes: 6d8192bd69bb ("ip6, udp6: Support MSG_SPLICE_PAGES")
+Reported-by: Hyunwoo Kim <imv4bel@gmail.com>
+Reported-by: Kuan-Ting Chen <h3xrabbit@gmail.com>
+Tested-by: Hyunwoo Kim <imv4bel@gmail.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Kuan-Ting Chen <h3xrabbit@gmail.com>
+Signed-off-by: Steffen Klassert <steffen.klassert@secunet.com>
+[bwh: Backported to 5.10: set the SKBTX_SHARED_FRAG flag in
+ ip_append_page() instead of __ip{,6}_append_data()]
+Signed-off-by: Ben Hutchings <benh@debian.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit a6cb440f274a22456ef3e86b457344f1678f38f9)
+
+Note: This is CVE-2026-43284 (first stage for DirtyFrag)
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ net/ipv4/esp4.c      | 3 ++-
+ net/ipv4/ip_output.c | 2 ++
+ net/ipv6/esp6.c      | 3 ++-
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/net/ipv4/esp4.c b/net/ipv4/esp4.c
+index 97689012b357..60728cf18f48 100644
+--- a/net/ipv4/esp4.c
++++ b/net/ipv4/esp4.c
+@@ -717,7 +717,8 @@ static int esp_input(struct xfrm_state *x, struct sk_buff *skb)
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 
+diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
+index 9c4e72e9c60a..7c9afbb27882 100644
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -1307,6 +1307,8 @@ ssize_t	ip_append_page(struct sock *sk, struct flowi4 *fl4, struct page *page,
+ 			goto error;
+ 		}
+ 
++		skb_shinfo(skb)->tx_flags |= SKBTX_SHARED_FRAG;
++
+ 		if (skb->ip_summed == CHECKSUM_NONE) {
+ 			__wsum csum;
+ 			csum = csum_page(page, offset, len);
+diff --git a/net/ipv6/esp6.c b/net/ipv6/esp6.c
+index 88a7579c23bd..893f71ca3456 100644
+--- a/net/ipv6/esp6.c
++++ b/net/ipv6/esp6.c
+@@ -639,7 +639,8 @@ static int esp6_input(struct xfrm_state *x, struct sk_buff *skb)
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -735,7 +735,42 @@ Patch1003: 0001-ACPI-processor-idle-Check-acpi_bus_get_device-return.patch
 Patch1004: 0001-scsi-target-Fix-XCOPY-NAA-identifier-lookup.patch
 Patch1005: 0001-ext4-fix-off-by-one-error-in-do_split.patch
 Patch1006: 0001-SUNRPC-Restore-missing-call-to-cancel_work_sync.patch
+# Copyfail mitigation
 Patch1007: 0001-crypto-disable-authencesn-module-for-CVE-2026-31431.patch
+# Copyfail fixes
+Patch1101: 0001-crypto-skcipher-Introduce-crypto_sync_skcipher.patch
+Patch1102: 0002-crypto-null-Remove-VLA-usage-of-skcipher.patch
+Patch1103: 0003-kabi-crypto-null-Remove-VLA-usage-of-skcipher.patch
+Patch1104: 0004-crypto-algif_skcipher-Cap-recv-SG-list-at-ctx-used.patch
+Patch1105: 0005-crypto-af_alg-Use-bh_lock_sock-in-sk_destruct.patch
+Patch1106: 0006-crypto-af_alg-fix-use-after-free-in-af_alg_accept-du.patch
+Patch1107: 0007-kabi-crypto-af_alg-fix-use-after-free-in-af_alg_acce.patch
+Patch1108: 0008-crypto-algif_aead-Only-wake-up-when-ctx-more-is-zero.patch
+Patch1109: 0009-kabi-crypto-algif_aead-Only-wake-up-when-ctx-more-is.patch
+Patch1110: 0010-crypto-algif_aead-fix-uninitialized-ctx-init.patch
+Patch1111: 0011-crypto-algif_skcipher-EBUSY-on-aio-should-be-an-erro.patch
+Patch1112: 0012-crypto-algif_aead-Do-not-set-MAY_BACKLOG-on-the-asyn.patch
+Patch1113: 0013-crypto-af_alg-Disallow-multiple-in-flight-AIO-reques.patch
+Patch1114: 0014-kabi-crypto-af_alg-Disallow-multiple-in-flight-AIO-r.patch
+Patch1115: 0015-crypto-af_alg-Work-around-empty-control-messages-wit.patch
+Patch1116: 0016-crypto-af_alg-Disallow-concurrent-writes-in-af_alg_s.patch
+Patch1117: 0017-crypto-af_alg-Fix-incorrect-boolean-values-in-af_alg.patch
+Patch1118: 0018-kabi-crypto-af_alg-Fix-incorrect-boolean-values-in-a.patch
+Patch1119: 0019-crypto-authencesn-reject-too-short-AAD-assoclen-8-to.patch
+Patch1120: 0020-crypto-af-alg-fix-NULL-pointer-dereference-in-scatte.patch
+Patch1121: 0021-crypto-authenc-use-memcpy_sglist-instead-of-null-skc.patch
+Patch1122: 0022-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst-f.patch
+Patch1123: 0023-crypto-doc-fix-kernel-doc-notation-in-chacha.c-and-a.patch
+Patch1124: 0024-crypto-algif_aead-use-memcpy_sglist-instead-of-null-.patch
+Patch1125: 0025-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+Patch1126: 0026-kabi-crypto-algif_aead-Revert-to-operating-out-of-pl.patch
+Patch1127: 0027-crypto-algif_aead-snapshot-IV-for-async-AEAD-request.patch
+Patch1128: 0028-crypto-scatterwalk-Backport-memcpy_sglist.patch
+Patch1129: 0029-crypto-algif_aead-Fix-minimum-RX-size-check-for-decr.patch
+Patch1130: 0030-crypto-af_alg-Fix-page-reassignment-overflow-in-af_a.patch
+Patch1131: 0031-crypto-authencesn-Fix-src-offset-when-decrypting-in-.patch
+# DirtyFrag / CopyFail2
+Patch1132: 0032-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags.patch
 
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
@@ -805,6 +840,8 @@ Provides: python2-perf
 %{?_cov_prepare}
 
 %build
+export KBUILD_SYMTYPES=y
+
 source %{SOURCE5}
 
 # This override tweaks the kernel makefiles so that we run debugedit on an
@@ -1090,6 +1127,10 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon May 11 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.3
+- Backports for CopyFail CVE-2026-31431 from linux-5.10.y
+- Backports for CVE-2026-43284 (DirtyFrag, XFRM-ESP path)from linux-5.10.y
+
 * Fri May 01 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.19.19-8.0.46.2
 - Disable authencesn module for CVE-2026-31431
 

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -1129,7 +1129,7 @@ fi
 %changelog
 * Mon May 11 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.3
 - Backports for CopyFail CVE-2026-31431 from linux-5.10.y
-- Backports for CVE-2026-43284 (DirtyFrag, XFRM-ESP path)from linux-5.10.y
+- Backports for CVE-2026-43284 (DirtyFrag, XFRM-ESP path or CopyFail2) from linux-5.10.y
 
 * Fri May 01 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.19.19-8.0.46.2
 - Disable authencesn module for CVE-2026-31431

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -36,13 +36,13 @@
 
 # Be strict when applying patches
 %if 0%{?xenserver} < 9
-%global __patch /usr/bin/patch --fuzz=0
+%global __patch /bin/patch -F0
 %endif
 
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.4%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -1127,9 +1127,12 @@ fi
 %{?_cov_results_package}
 
 %changelog
-* Mon May 11 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.3
+* Mon May 11 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.4
 - Backports for CopyFail CVE-2026-31431 from linux-5.10.y
 - Backports for CVE-2026-43284 (DirtyFrag, XFRM-ESP path or CopyFail2) from linux-5.10.y
+
+* Tue May 05 2026 Yann Dirson <yann.dirson@vates.tech> - 4.19.19-8.0.46.3
+- Use short flag and short path to patch command to avoid overflowing a rpm limitation
 
 * Fri May 01 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.19.19-8.0.46.2
 - Disable authencesn module for CVE-2026-31431


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3256

#### Related changes (optional)

XCPNG-3243

#### Context & Motivation

Fixes:
- [CVE-2026-31431](https://github.com/advisories/GHSA-2274-3hgr-wxv6) (CopyFail) not by disabling the `authencesn` kernel module but by backporting patches from the linux-4.19.y and linux-5.10.y stable branches along with kABI neutralization commits, unlike our prior work in https://github.com/xcp-ng-rpms/kernel/pull/29.
- [CVE-2026-43284](https://github.com/V4bel/dirtyfrag) (used by the DirtyFrag exploit) by back-porting the fix from linux-5.10.y.

> [!NOTE]
> Our kernel is not vulnerable to CVE-2026-43500 (also used by the DirtyFrag exploit) because the vulnerable code was introduced in ~v6.5 and not backported to our v4.19 version.  Upstream LTS also didn't backport it to linux-5.10.y.

Source code review is in process at: https://github.com/xcp-ng/linux/pull/3

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

I would say ASAP, although the fact it is a local privilege escalation is defense in depth for the threat model of the dom0 kernel.

---

### Release Notes and Documentation

#### Explain the change to users

- Fixes CVE-2026-43284 (used by the DirtyFrag and CopyFail2 exploits).
- Bug fixes in the crypto sub-system in the linux kernel

#### Attention points

N/A.

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

EXPLANATIONS
N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Nothing so far, but will try the various exploits (DirtyFrag, CopyFail, CopyFail2).

#### What manual tests should be performed after the build, and by whom?

Running a test-suite specifically targetting the crypto sub-system would be a good thing given the sheer amount of changes.

#### What's covered by the xcp-ng-tests test suite?

Main tests

#### What tests have been or will be added to CI for this change? If none, explain why.

N/A

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
