### PR TITLE
Add fixes for CVE-2026-46300, CVE-2026-4633 and CVE-2026-43494.

### DIFF
--- a/SOURCES/0001-ptrace-restore-smp_rmb-in-__ptrace_may_access.patch
+++ b/SOURCES/0001-ptrace-restore-smp_rmb-in-__ptrace_may_access.patch
@@ -1,0 +1,67 @@
+From c8d4c97047d2f7c8d0492e648cb023e313bf211e Mon Sep 17 00:00:00 2001
+From: Jann Horn <jannh@google.com>
+Date: Wed, 29 May 2019 13:31:57 +0200
+Subject: [PATCH] ptrace: restore smp_rmb() in __ptrace_may_access()
+
+commit f6581f5b55141a95657ef5742cf6a6bfa20a109f upstream.
+
+Restore the read memory barrier in __ptrace_may_access() that was deleted
+a couple years ago. Also add comments on this barrier and the one it pairs
+with to explain why they're there (as far as I understand).
+
+Fixes: bfedb589252c ("mm: Add a user_ns owner to mm_struct and fix ptrace permission checks")
+Cc: stable@vger.kernel.org
+Acked-by: Kees Cook <keescook@chromium.org>
+Acked-by: Oleg Nesterov <oleg@redhat.com>
+Signed-off-by: Jann Horn <jannh@google.com>
+Signed-off-by: Eric W. Biederman <ebiederm@xmission.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+(cherry picked from commit 31e216cf9dc2346a20e8361b55807ef7135459c6)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ kernel/cred.c   |  9 +++++++++
+ kernel/ptrace.c | 10 ++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/kernel/cred.c b/kernel/cred.c
+index ecf03657e71c..efd04b2ec84c 100644
+--- a/kernel/cred.c
++++ b/kernel/cred.c
+@@ -448,6 +448,15 @@ int commit_creds(struct cred *new)
+ 		if (task->mm)
+ 			set_dumpable(task->mm, suid_dumpable);
+ 		task->pdeath_signal = 0;
++		/*
++		 * If a task drops privileges and becomes nondumpable,
++		 * the dumpability change must become visible before
++		 * the credential change; otherwise, a __ptrace_may_access()
++		 * racing with this change may be able to attach to a task it
++		 * shouldn't be able to attach to (as if the task had dropped
++		 * privileges without becoming nondumpable).
++		 * Pairs with a read barrier in __ptrace_may_access().
++		 */
+ 		smp_wmb();
+ 	}
+ 
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index 21fec73d45d4..79a0eb0d0a21 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -322,6 +322,16 @@ static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
+ 	return -EPERM;
+ ok:
+ 	rcu_read_unlock();
++	/*
++	 * If a task drops privileges and becomes nondumpable (through a syscall
++	 * like setresuid()) while we are trying to access it, we must ensure
++	 * that the dumpability is read after the credentials; otherwise,
++	 * we may be able to attach to a task that we shouldn't be able to
++	 * attach to (as if the task had dropped privileges without becoming
++	 * nondumpable).
++	 * Pairs with a write barrier in commit_creds().
++	 */
++	smp_rmb();
+ 	mm = task->mm;
+ 	if (mm &&
+ 	    ((get_dumpable(mm) != SUID_DUMP_USER) &&

--- a/SOURCES/0002-ptrace-slightly-saner-get_dumpable-logic.patch
+++ b/SOURCES/0002-ptrace-slightly-saner-get_dumpable-logic.patch
@@ -1,0 +1,117 @@
+From 7f53dd12fb0bf936befb1a116be2654927df653d Mon Sep 17 00:00:00 2001
+From: Linus Torvalds <torvalds@linux-foundation.org>
+Date: Wed, 13 May 2026 11:37:18 -0700
+Subject: [PATCH] ptrace: slightly saner 'get_dumpable()' logic
+
+commit 31e62c2ebbfdc3fe3dbdf5e02c92a9dc67087a3a upstream.
+
+The 'dumpability' of a task is fundamentally about the memory image of
+the task - the concept comes from whether it can core dump or not - and
+makes no sense when you don't have an associated mm.
+
+And almost all users do in fact use it only for the case where the task
+has a mm pointer.
+
+But we have one odd special case: ptrace_may_access() uses 'dumpable' to
+check various other things entirely independently of the MM (typically
+explicitly using flags like PTRACE_MODE_READ_FSCREDS).  Including for
+threads that no longer have a VM (and maybe never did, like most kernel
+threads).
+
+It's not what this flag was designed for, but it is what it is.
+
+The ptrace code does check that the uid/gid matches, so you do have to
+be uid-0 to see kernel thread details, but this means that the
+traditional "drop capabilities" model doesn't make any difference for
+this all.
+
+Make it all make a *bit* more sense by saying that if you don't have a
+MM pointer, we'll use a cached "last dumpability" flag if the thread
+ever had a MM (it will be zero for kernel threads since it is never
+set), and require a proper CAP_SYS_PTRACE capability to override.
+
+Reported-by: Qualys Security Advisory <qsa@qualys.com>
+Cc: Oleg Nesterov <oleg@redhat.com>
+Cc: Kees Cook <kees@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+[uli: backport to 4.19]
+Signed-off-by: Ulrich Hecht <uli@kernel.org>
+(cherry picked from commit 874e7cb1436fc0968a8ef0bdec3664f3f9822f7a)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ include/linux/sched.h |  3 +++
+ kernel/exit.c         |  1 +
+ kernel/ptrace.c       | 22 ++++++++++++++++------
+ 3 files changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/include/linux/sched.h b/include/linux/sched.h
+index 4abb5bd74b04..754dcc9dc502 100644
+--- a/include/linux/sched.h
++++ b/include/linux/sched.h
+@@ -715,6 +715,9 @@ struct task_struct {
+ 
+ 	/* Unserialized, strictly 'current' */
+ 
++	/* Save user-dumpable when mm goes away */
++	unsigned			user_dumpable:1;
++
+ 	/* Bit to tell LSMs we're in execve(): */
+ 	unsigned			in_execve:1;
+ 	unsigned			in_iowait:1;
+diff --git a/kernel/exit.c b/kernel/exit.c
+index 0e21e6d21f35..f0b5dc90eb2b 100644
+--- a/kernel/exit.c
++++ b/kernel/exit.c
+@@ -537,6 +537,7 @@ static void exit_mm(void)
+ 	BUG_ON(mm != current->active_mm);
+ 	/* more a memory barrier than a real lock */
+ 	task_lock(current);
++	current->user_dumpable = (get_dumpable(mm) == SUID_DUMP_USER);
+ 	current->mm = NULL;
+ 	up_read(&mm->mmap_sem);
+ 	enter_lazy_tlb(mm, current);
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index 79a0eb0d0a21..b55e9a4504f3 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -267,11 +267,24 @@ static int ptrace_has_cap(struct user_namespace *ns, unsigned int mode)
+ 		return has_ns_capability(current, ns, CAP_SYS_PTRACE);
+ }
+ 
++static bool task_still_dumpable(struct task_struct *task, unsigned int mode)
++{
++	struct mm_struct *mm = task->mm;
++	if (mm) {
++		if (get_dumpable(mm) == SUID_DUMP_USER)
++			return true;
++		return ptrace_has_cap(mm->user_ns, mode);
++	}
++
++	if (task->user_dumpable)
++		return true;
++	return ptrace_has_cap(&init_user_ns, mode);
++}
++
+ /* Returns 0 on success, -errno on denial. */
+ static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
+ {
+ 	const struct cred *cred = current_cred(), *tcred;
+-	struct mm_struct *mm;
+ 	kuid_t caller_uid;
+ 	kgid_t caller_gid;
+ 
+@@ -332,11 +345,8 @@ static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
+ 	 * Pairs with a write barrier in commit_creds().
+ 	 */
+ 	smp_rmb();
+-	mm = task->mm;
+-	if (mm &&
+-	    ((get_dumpable(mm) != SUID_DUMP_USER) &&
+-	     !ptrace_has_cap(mm->user_ns, mode)))
+-	    return -EPERM;
++	if (!task_still_dumpable(task, mode))
++		return -EPERM;
+ 
+ 	return security_ptrace_access_check(task, mode);
+ }

--- a/SOURCES/0003-kabi-ptrace-slightly-saner-get_dumpable-logic.patch
+++ b/SOURCES/0003-kabi-ptrace-slightly-saner-get_dumpable-logic.patch
@@ -1,0 +1,690 @@
+From 26ba6639ed3fc9646cecbbd2d6a2d14795847425 Mon Sep 17 00:00:00 2001
+From: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+Date: Tue, 26 May 2026 11:18:00 +0200
+Subject: [PATCH] !kabi ptrace: slightly saner 'get_dumpable()' logic
+
+This work-arounds kABI changes introduced by the user_dumpable field
+addition to the struct task_struct.  It's easy enough to move below to a
+hole and hide it from __GENKSYMS__.
+
+Fixes: 7f53dd12fb0b ("ptrace: slightly saner 'get_dumpable()' logic")
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ include/linux/sched.h |  13 +-
+ kernel/ptrace.c       | 635 ++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 645 insertions(+), 3 deletions(-)
+
+diff --git a/include/linux/sched.h b/include/linux/sched.h
+index 754dcc9dc502..c4a3199a9def 100644
+--- a/include/linux/sched.h
++++ b/include/linux/sched.h
+@@ -715,9 +715,6 @@ struct task_struct {
+ 
+ 	/* Unserialized, strictly 'current' */
+ 
+-	/* Save user-dumpable when mm goes away */
+-	unsigned			user_dumpable:1;
+-
+ 	/* Bit to tell LSMs we're in execve(): */
+ 	unsigned			in_execve:1;
+ 	unsigned			in_iowait:1;
+@@ -741,6 +738,16 @@ struct task_struct {
+ 	/* to be used once the psi infrastructure lands upstream. */
+ 	unsigned			use_memdelay:1;
+ #endif
++#ifndef __GENKSYMS__
++	/**
++	 * 7f53dd12fb0b ("ptrace: slightly saner 'get_dumpable()' logic")
++	 * added the user_dumpable field, so hide it from genksyms to avoid
++	 * kABI changes.  Also move it inside a hole to avoid changing
++	 * offsets of other fields.
++	 */
++	/* Save user-dumpable when mm goes away */
++	unsigned			user_dumpable:1;
++#endif
+ 
+ 	unsigned long			atomic_flags; /* Flags requiring atomic access. */
+ 
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index b55e9a4504f3..3d944df81fe7 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -1317,3 +1317,638 @@ COMPAT_SYSCALL_DEFINE4(ptrace, compat_long_t, request, compat_long_t, pid,
+ 	return ret;
+ }
+ #endif	/* CONFIG_COMPAT */
++
++void kabi_check_task_struct_user_dumpable(void)
++{
++	struct old_task_struct {
++#ifdef CONFIG_THREAD_INFO_IN_TASK
++		/*
++		 * For reasons of header soup (see current_thread_info()), this
++		 * must be the first element of task_struct.
++		 */
++		struct thread_info		thread_info;
++#endif
++		/* -1 unrunnable, 0 runnable, >0 stopped: */
++		volatile long			state;
++
++		/*
++		 * This begins the randomizable portion of task_struct. Only
++		 * scheduling-critical items should be added above here.
++		 */
++		randomized_struct_fields_start
++
++		void				*stack;
++		atomic_t			usage;
++		/* Per task flags (PF_*), defined further below: */
++		unsigned int			flags;
++		unsigned int			ptrace;
++
++#ifdef CONFIG_SMP
++		struct llist_node		wake_entry;
++		int				on_cpu;
++#ifdef CONFIG_THREAD_INFO_IN_TASK
++		/* Current CPU: */
++		unsigned int			cpu;
++#endif
++		unsigned int			wakee_flips;
++		unsigned long			wakee_flip_decay_ts;
++		struct task_struct		*last_wakee;
++
++		/*
++		 * recent_used_cpu is initially set as the last CPU used by a task
++		 * that wakes affine another task. Waker/wakee relationships can
++		 * push tasks around a CPU where each wakeup moves to the next one.
++		 * Tracking a recently used CPU allows a quick search for a recently
++		 * used CPU that may be idle.
++		 */
++		int				recent_used_cpu;
++		int				wake_cpu;
++#endif
++		int				on_rq;
++
++		int				prio;
++		int				static_prio;
++		int				normal_prio;
++		unsigned int			rt_priority;
++
++		const struct sched_class	*sched_class;
++		struct sched_entity		se;
++		struct sched_rt_entity		rt;
++#ifdef CONFIG_CGROUP_SCHED
++		struct task_group		*sched_task_group;
++#endif
++		struct sched_dl_entity		dl;
++
++#ifdef CONFIG_PREEMPT_NOTIFIERS
++		/* List of struct preempt_notifier: */
++		struct hlist_head		preempt_notifiers;
++#endif
++
++#ifdef CONFIG_BLK_DEV_IO_TRACE
++		unsigned int			btrace_seq;
++#endif
++
++		unsigned int			policy;
++		int				nr_cpus_allowed;
++		cpumask_t			cpus_allowed;
++
++#ifdef CONFIG_PREEMPT_RCU
++		int				rcu_read_lock_nesting;
++		union rcu_special		rcu_read_unlock_special;
++		struct list_head		rcu_node_entry;
++		struct rcu_node			*rcu_blocked_node;
++#endif /* #ifdef CONFIG_PREEMPT_RCU */
++
++#ifdef CONFIG_TASKS_RCU
++		unsigned long			rcu_tasks_nvcsw;
++		u8				rcu_tasks_holdout;
++		u8				rcu_tasks_idx;
++		int				rcu_tasks_idle_cpu;
++		struct list_head		rcu_tasks_holdout_list;
++#endif /* #ifdef CONFIG_TASKS_RCU */
++
++		struct sched_info		sched_info;
++
++		struct list_head		tasks;
++#ifdef CONFIG_SMP
++		struct plist_node		pushable_tasks;
++		struct rb_node			pushable_dl_tasks;
++#endif
++
++		struct mm_struct		*mm;
++		struct mm_struct		*active_mm;
++
++		/* Per-thread vma caching: */
++		struct vmacache			vmacache;
++
++#ifdef SPLIT_RSS_COUNTING
++		struct task_rss_stat		rss_stat;
++#endif
++		int				exit_state;
++		int				exit_code;
++		int				exit_signal;
++		/* The signal sent when the parent dies: */
++		int				pdeath_signal;
++		/* JOBCTL_*, siglock protected: */
++		unsigned long			jobctl;
++
++		/* Used for emulating ABI behavior of previous Linux versions: */
++		unsigned int			personality;
++
++		/* Scheduler bits, serialized by scheduler locks: */
++		unsigned			sched_reset_on_fork:1;
++		unsigned			sched_contributes_to_load:1;
++		unsigned			sched_migrated:1;
++		unsigned			sched_remote_wakeup:1;
++		/* Force alignment to the next boundary: */
++		unsigned			:0;
++
++		/* Unserialized, strictly 'current' */
++
++		/* Bit to tell LSMs we're in execve(): */
++		unsigned			in_execve:1;
++		unsigned			in_iowait:1;
++#ifndef TIF_RESTORE_SIGMASK
++		unsigned			restore_sigmask:1;
++#endif
++#ifdef CONFIG_MEMCG
++		unsigned			in_user_fault:1;
++#ifdef CONFIG_MEMCG_KMEM
++		unsigned			memcg_kmem_skip_account:1;
++#endif
++#endif
++#ifdef CONFIG_COMPAT_BRK
++		unsigned			brk_randomized:1;
++#endif
++#ifdef CONFIG_CGROUPS
++		/* disallow userland-initiated cgroup migration */
++		unsigned			no_cgroup_migration:1;
++#endif
++#ifdef CONFIG_BLK_CGROUP
++		/* to be used once the psi infrastructure lands upstream. */
++		unsigned			use_memdelay:1;
++#endif
++#ifndef __GENKSYMS__
++		/**
++		 * 7f53dd12fb0b ("ptrace: slightly saner 'get_dumpable()' logic")
++		 * added the user_dumpable field, so hide it from genksyms to avoid
++		 * kABI changes.  Also move it inside a hole to avoid changing
++		 * offsets of other fields.
++		 */
++		/* Save user-dumpable when mm goes away */
++		unsigned			user_dumpable:1;
++#endif
++
++		unsigned long			atomic_flags; /* Flags requiring atomic access. */
++
++		struct restart_block		restart_block;
++
++		pid_t				pid;
++		pid_t				tgid;
++
++#ifdef CONFIG_STACKPROTECTOR
++		/* Canary value for the -fstack-protector GCC feature: */
++		unsigned long			stack_canary;
++#endif
++		/*
++		 * Pointers to the (original) parent process, youngest child, younger sibling,
++		 * older sibling, respectively.  (p->father can be replaced with
++		 * p->real_parent->pid)
++		 */
++
++		/* Real parent process: */
++		struct task_struct __rcu	*real_parent;
++
++		/* Recipient of SIGCHLD, wait4() reports: */
++		struct task_struct __rcu	*parent;
++
++		/*
++		 * Children/sibling form the list of natural children:
++		 */
++		struct list_head		children;
++		struct list_head		sibling;
++		struct task_struct		*group_leader;
++
++		/*
++		 * 'ptraced' is the list of tasks this task is using ptrace() on.
++		 *
++		 * This includes both natural children and PTRACE_ATTACH targets.
++		 * 'ptrace_entry' is this task's link on the p->parent->ptraced list.
++		 */
++		struct list_head		ptraced;
++		struct list_head		ptrace_entry;
++
++		/* PID/PID hash table linkage. */
++		struct pid			*thread_pid;
++		struct hlist_node		pid_links[PIDTYPE_MAX];
++		struct list_head		thread_group;
++		struct list_head		thread_node;
++
++		struct completion		*vfork_done;
++
++		/* CLONE_CHILD_SETTID: */
++		int __user			*set_child_tid;
++
++		/* CLONE_CHILD_CLEARTID: */
++		int __user			*clear_child_tid;
++
++		u64				utime;
++		u64				stime;
++#ifdef CONFIG_ARCH_HAS_SCALED_CPUTIME
++		u64				utimescaled;
++		u64				stimescaled;
++#endif
++		u64				gtime;
++		struct prev_cputime		prev_cputime;
++#ifdef CONFIG_VIRT_CPU_ACCOUNTING_GEN
++		struct vtime			vtime;
++#endif
++
++#ifdef CONFIG_NO_HZ_FULL
++		atomic_t			tick_dep_mask;
++#endif
++		/* Context switch counts: */
++		unsigned long			nvcsw;
++		unsigned long			nivcsw;
++
++		/* Monotonic time in nsecs: */
++		u64				start_time;
++
++		/* Boot based time in nsecs: */
++		u64				real_start_time;
++
++		/* MM fault and swap info: this can arguably be seen as either mm-specific or thread-specific: */
++		unsigned long			min_flt;
++		unsigned long			maj_flt;
++
++#ifdef CONFIG_POSIX_TIMERS
++		struct task_cputime		cputime_expires;
++		struct list_head		cpu_timers[3];
++#endif
++
++		/* Process credentials: */
++
++		/* Tracer's credentials at attach: */
++		const struct cred __rcu		*ptracer_cred;
++
++		/* Objective and real subjective task credentials (COW): */
++		const struct cred __rcu		*real_cred;
++
++		/* Effective (overridable) subjective task credentials (COW): */
++		const struct cred __rcu		*cred;
++
++		/*
++		 * executable name, excluding path.
++		 *
++		 * - normally initialized setup_new_exec()
++		 * - access it with [gs]et_task_comm()
++		 * - lock it with task_lock()
++		 */
++		char				comm[TASK_COMM_LEN];
++
++		struct nameidata		*nameidata;
++
++#ifdef CONFIG_SYSVIPC
++		struct sysv_sem			sysvsem;
++		struct sysv_shm			sysvshm;
++#endif
++#ifdef CONFIG_DETECT_HUNG_TASK
++		unsigned long			last_switch_count;
++		unsigned long			last_switch_time;
++#endif
++		/* Filesystem information: */
++		struct fs_struct		*fs;
++
++		/* Open file information: */
++		struct files_struct		*files;
++
++		/* Namespaces: */
++		struct nsproxy			*nsproxy;
++
++		/* Signal handlers: */
++		struct signal_struct		*signal;
++		struct sighand_struct		*sighand;
++		sigset_t			blocked;
++		sigset_t			real_blocked;
++		/* Restored if set_restore_sigmask() was used: */
++		sigset_t			saved_sigmask;
++		struct sigpending		pending;
++		unsigned long			sas_ss_sp;
++		size_t				sas_ss_size;
++		unsigned int			sas_ss_flags;
++
++		struct callback_head		*task_works;
++
++		struct audit_context		*audit_context;
++#ifdef CONFIG_AUDITSYSCALL
++		kuid_t				loginuid;
++		unsigned int			sessionid;
++#endif
++		struct seccomp			seccomp;
++
++		/* Thread group tracking: */
++		u32				parent_exec_id;
++		u32				self_exec_id;
++
++		/* Protection against (de-)allocation: mm, files, fs, tty, keyrings, mems_allowed, mempolicy: */
++		spinlock_t			alloc_lock;
++
++		/* Protection of the PI data structures: */
++		raw_spinlock_t			pi_lock;
++
++		struct wake_q_node		wake_q;
++
++#ifdef CONFIG_RT_MUTEXES
++		/* PI waiters blocked on a rt_mutex held by this task: */
++		struct rb_root_cached		pi_waiters;
++		/* Updated under owner's pi_lock and rq lock */
++		struct task_struct		*pi_top_task;
++		/* Deadlock detection and priority inheritance handling: */
++		struct rt_mutex_waiter		*pi_blocked_on;
++#endif
++
++#ifdef CONFIG_DEBUG_MUTEXES
++		/* Mutex deadlock detection: */
++		struct mutex_waiter		*blocked_on;
++#endif
++
++#ifdef CONFIG_TRACE_IRQFLAGS
++		unsigned int			irq_events;
++		unsigned long			hardirq_enable_ip;
++		unsigned long			hardirq_disable_ip;
++		unsigned int			hardirq_enable_event;
++		unsigned int			hardirq_disable_event;
++		int				hardirqs_enabled;
++		int				hardirq_context;
++		unsigned long			softirq_disable_ip;
++		unsigned long			softirq_enable_ip;
++		unsigned int			softirq_disable_event;
++		unsigned int			softirq_enable_event;
++		int				softirqs_enabled;
++		int				softirq_context;
++#endif
++
++#ifdef CONFIG_LOCKDEP
++# define MAX_LOCK_DEPTH			48UL
++		u64				curr_chain_key;
++		int				lockdep_depth;
++		unsigned int			lockdep_recursion;
++		struct held_lock		held_locks[MAX_LOCK_DEPTH];
++#endif
++
++#ifdef CONFIG_UBSAN
++		unsigned int			in_ubsan;
++#endif
++
++		/* Journalling filesystem info: */
++		void				*journal_info;
++
++		/* Stacked block device info: */
++		struct bio_list			*bio_list;
++
++#ifdef CONFIG_BLOCK
++		/* Stack plugging: */
++		struct blk_plug			*plug;
++#endif
++
++		/* VM state: */
++		struct reclaim_state		*reclaim_state;
++
++		struct backing_dev_info		*backing_dev_info;
++
++		struct io_context		*io_context;
++
++		/* Ptrace state: */
++		unsigned long			ptrace_message;
++		siginfo_t			*last_siginfo;
++
++		struct task_io_accounting	ioac;
++#ifdef CONFIG_TASK_XACCT
++		/* Accumulated RSS usage: */
++		u64				acct_rss_mem1;
++		/* Accumulated virtual memory usage: */
++		u64				acct_vm_mem1;
++		/* stime + utime since last update: */
++		u64				acct_timexpd;
++#endif
++#ifdef CONFIG_CPUSETS
++		/* Protected by ->alloc_lock: */
++		nodemask_t			mems_allowed;
++		/* Seqence number to catch updates: */
++		seqcount_t			mems_allowed_seq;
++		int				cpuset_mem_spread_rotor;
++		int				cpuset_slab_spread_rotor;
++#endif
++#ifdef CONFIG_CGROUPS
++		/* Control Group info protected by css_set_lock: */
++		struct css_set __rcu		*cgroups;
++		/* cg_list protected by css_set_lock and tsk->alloc_lock: */
++		struct list_head		cg_list;
++#endif
++#ifdef CONFIG_INTEL_RDT
++		u32				closid;
++		u32				rmid;
++#endif
++#ifdef CONFIG_FUTEX
++		struct robust_list_head __user	*robust_list;
++#ifdef CONFIG_COMPAT
++		struct compat_robust_list_head __user *compat_robust_list;
++#endif
++		struct list_head		pi_state_list;
++		struct futex_pi_state		*pi_state_cache;
++#endif
++#ifdef CONFIG_PERF_EVENTS
++		struct perf_event_context	*perf_event_ctxp[perf_nr_task_contexts];
++		struct mutex			perf_event_mutex;
++		struct list_head		perf_event_list;
++#endif
++#ifdef CONFIG_DEBUG_PREEMPT
++		unsigned long			preempt_disable_ip;
++#endif
++#ifdef CONFIG_NUMA
++		/* Protected by alloc_lock: */
++		struct mempolicy		*mempolicy;
++		short				il_prev;
++		short				pref_node_fork;
++#endif
++#ifdef CONFIG_NUMA_BALANCING
++		int				numa_scan_seq;
++		unsigned int			numa_scan_period;
++		unsigned int			numa_scan_period_max;
++		int				numa_preferred_nid;
++		unsigned long			numa_migrate_retry;
++		/* Migration stamp: */
++		u64				node_stamp;
++		u64				last_task_numa_placement;
++		u64				last_sum_exec_runtime;
++		struct callback_head		numa_work;
++
++		struct numa_group		*numa_group;
++
++		/*
++		 * numa_faults is an array split into four regions:
++		 * faults_memory, faults_cpu, faults_memory_buffer, faults_cpu_buffer
++		 * in this precise order.
++		 *
++		 * faults_memory: Exponential decaying average of faults on a per-node
++		 * basis. Scheduling placement decisions are made based on these
++		 * counts. The values remain static for the duration of a PTE scan.
++		 * faults_cpu: Track the nodes the process was running on when a NUMA
++		 * hinting fault was incurred.
++		 * faults_memory_buffer and faults_cpu_buffer: Record faults per node
++		 * during the current scan window. When the scan completes, the counts
++		 * in faults_memory and faults_cpu decay and these values are copied.
++		 */
++		unsigned long			*numa_faults;
++		unsigned long			total_numa_faults;
++
++		/*
++		 * numa_faults_locality tracks if faults recorded during the last
++		 * scan window were remote/local or failed to migrate. The task scan
++		 * period is adapted based on the locality of the faults with different
++		 * weights depending on whether they were shared or private faults
++		 */
++		unsigned long			numa_faults_locality[3];
++
++		unsigned long			numa_pages_migrated;
++#endif /* CONFIG_NUMA_BALANCING */
++
++#ifdef CONFIG_RSEQ
++		struct rseq __user *rseq;
++		u32 rseq_len;
++		u32 rseq_sig;
++		/*
++		 * RmW on rseq_event_mask must be performed atomically
++		 * with respect to preemption.
++		 */
++		unsigned long rseq_event_mask;
++#endif
++
++		struct tlbflush_unmap_batch	tlb_ubc;
++
++		struct rcu_head			rcu;
++
++		/* Cache last used pipe for splice(): */
++		struct pipe_inode_info		*splice_pipe;
++
++		struct page_frag		task_frag;
++
++#ifdef CONFIG_TASK_DELAY_ACCT
++		struct task_delay_info		*delays;
++#endif
++
++#ifdef CONFIG_FAULT_INJECTION
++		int				make_it_fail;
++		unsigned int			fail_nth;
++#endif
++		/*
++		 * When (nr_dirtied >= nr_dirtied_pause), it's time to call
++		 * balance_dirty_pages() for a dirty throttling pause:
++		 */
++		int				nr_dirtied;
++		int				nr_dirtied_pause;
++		/* Start of a write-and-pause period: */
++		unsigned long			dirty_paused_when;
++
++#ifdef CONFIG_LATENCYTOP
++		int				latency_record_count;
++		struct latency_record		latency_record[LT_SAVECOUNT];
++#endif
++		/*
++		 * Time slack values; these are used to round up poll() and
++		 * select() etc timeout values. These are in nanoseconds.
++		 */
++		u64				timer_slack_ns;
++		u64				default_timer_slack_ns;
++
++#ifdef CONFIG_KASAN
++		unsigned int			kasan_depth;
++#endif
++
++#ifdef CONFIG_FUNCTION_GRAPH_TRACER
++		/* Index of current stored address in ret_stack: */
++		int				curr_ret_stack;
++		int				curr_ret_depth;
++
++		/* Stack of return addresses for return function tracing: */
++		struct ftrace_ret_stack		*ret_stack;
++
++		/* Timestamp for last schedule: */
++		unsigned long long		ftrace_timestamp;
++
++		/*
++		 * Number of functions that haven't been traced
++		 * because of depth overrun:
++		 */
++		atomic_t			trace_overrun;
++
++		/* Pause tracing: */
++		atomic_t			tracing_graph_pause;
++#endif
++
++#ifdef CONFIG_TRACING
++		/* State flags for use by tracers: */
++		unsigned long			trace;
++
++		/* Bitmask and counter of trace recursion: */
++		unsigned long			trace_recursion;
++#endif /* CONFIG_TRACING */
++
++#ifdef CONFIG_KCOV
++		/* Coverage collection mode enabled for this task (0 if disabled): */
++		unsigned int			kcov_mode;
++
++		/* Size of the kcov_area: */
++		unsigned int			kcov_size;
++
++		/* Buffer for coverage collection: */
++		void				*kcov_area;
++
++		/* KCOV descriptor wired with this task or NULL: */
++		struct kcov			*kcov;
++#endif
++
++#ifdef CONFIG_MEMCG
++		struct mem_cgroup		*memcg_in_oom;
++		gfp_t				memcg_oom_gfp_mask;
++		int				memcg_oom_order;
++
++		/* Number of pages to reclaim on returning to userland: */
++		unsigned int			memcg_nr_pages_over_high;
++
++		/* Used by memcontrol for targeted memcg charge: */
++		struct mem_cgroup		*active_memcg;
++#endif
++
++#ifdef CONFIG_BLK_CGROUP
++		struct request_queue		*throttle_queue;
++#endif
++
++#ifdef CONFIG_UPROBES
++		struct uprobe_task		*utask;
++#endif
++#if defined(CONFIG_BCACHE) || defined(CONFIG_BCACHE_MODULE)
++		unsigned int			sequential_io;
++		unsigned int			sequential_io_avg;
++#endif
++#ifdef CONFIG_DEBUG_ATOMIC_SLEEP
++		unsigned long			task_state_change;
++#endif
++		int				pagefault_disabled;
++#ifdef CONFIG_MMU
++		struct task_struct		*oom_reaper_list;
++#endif
++#ifdef CONFIG_VMAP_STACK
++		struct vm_struct		*stack_vm_area;
++#endif
++#ifdef CONFIG_THREAD_INFO_IN_TASK
++		/* A live task holds one reference: */
++		atomic_t			stack_refcount;
++#endif
++#ifdef CONFIG_LIVEPATCH
++		int patch_state;
++#endif
++#ifdef CONFIG_SECURITY
++		/* Used by LSM modules for access restriction: */
++		void				*security;
++#endif
++
++		/*
++		 * New fields for task_struct should be added above here, so that
++		 * they are included in the randomized portion of task_struct.
++		 */
++		randomized_struct_fields_end
++
++		/* CPU-specific state of this task: */
++		struct thread_struct		thread;
++
++		/*
++		 * WARNING: on x86, 'thread_struct' contains a variable-sized
++		 * structure.  It *MUST* be at the end of 'task_struct'.
++		 *
++		 * Do not put anything below here!
++		 */
++	};
++	BUILD_BUG_ON(sizeof(struct old_task_struct) != sizeof(struct task_struct));
++	BUILD_BUG_ON(offsetof(struct old_task_struct, atomic_flags) != offsetof(struct task_struct, atomic_flags));
++}

--- a/SOURCES/0004-net-skbuff-preserve-shared-frag-marker-during-coales.patch
+++ b/SOURCES/0004-net-skbuff-preserve-shared-frag-marker-during-coales.patch
@@ -1,0 +1,53 @@
+From 90dcecc271d00dbf6bd63d1034936768a7f353f1 Mon Sep 17 00:00:00 2001
+From: William Bowling <vakzz@zellic.io>
+Date: Wed, 13 May 2026 04:16:35 +0000
+Subject: [PATCH] net: skbuff: preserve shared-frag marker during coalescing
+
+commit f84eca5817390257cef78013d0112481c503b4a3 upstream.
+
+skb_try_coalesce() can attach paged frags from @from to @to.  If @from
+has SKBFL_SHARED_FRAG set, the resulting @to skb can contain the same
+externally-owned or page-cache-backed frags, but the shared-frag marker
+is currently lost.
+
+That breaks the invariant relied on by later in-place writers.  In
+particular, ESP input checks skb_has_shared_frag() before deciding
+whether an uncloned nonlinear skb can skip skb_cow_data().  If TCP
+receive coalescing has moved shared frags into an unmarked skb, ESP can
+see skb_has_shared_frag() as false and decrypt in place over page-cache
+backed frags.
+
+Propagate SKBFL_SHARED_FRAG when skb_try_coalesce() transfers paged
+frags.  The tailroom copy path does not need the marker because it copies
+bytes into @to's linear data rather than transferring frag descriptors.
+
+Fixes: cef401de7be8 ("net: fix possible wrong checksum generation")
+Fixes: f4c50a4034e6 ("xfrm: esp: avoid in-place decrypt on shared skb frags")
+Signed-off-by: William Bowling <vakzz@zellic.io>
+Reviewed-by: Eric Dumazet <edumazet@google.com>
+Tested-by: Jiayuan Chen <jiayuan.chen@linux.dev>
+Link: https://patch.msgid.link/20260513041635.1289541-1-vakzz@zellic.io
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+[bwh: Backported to 5.10: Set the SKBTX_SHARED_FRAG flag in
+ sk_buff::tx_flags, instead of SKBFL_SHARED_FRAG in sk_buff::flags]
+Signed-off-by: Ben Hutchings <benh@debian.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 3599e6b3cc1ada96883d496a50a210d3afbb6987)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ net/core/skbuff.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/net/core/skbuff.c b/net/core/skbuff.c
+index f99165f7216a..e03afb7a1528 100644
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -4870,6 +4870,8 @@ bool skb_try_coalesce(struct sk_buff *to, struct sk_buff *from,
+ 	       from_shinfo->frags,
+ 	       from_shinfo->nr_frags * sizeof(skb_frag_t));
+ 	to_shinfo->nr_frags += from_shinfo->nr_frags;
++	if (from_shinfo->nr_frags)
++		to_shinfo->tx_flags |= from_shinfo->tx_flags & SKBTX_SHARED_FRAG;
+ 
+ 	if (!skb_cloned(from))
+ 		from_shinfo->nr_frags = 0;

--- a/SOURCES/0005-net-skbuff-propagate-shared-frag-marker-through-frag.patch
+++ b/SOURCES/0005-net-skbuff-propagate-shared-frag-marker-through-frag.patch
@@ -1,0 +1,141 @@
+From 73f29b1d6a97a91709a653cd856d4106b1e0ae40 Mon Sep 17 00:00:00 2001
+From: Hyunwoo Kim <imv4bel@gmail.com>
+Date: Sat, 16 May 2026 07:28:53 +0900
+Subject: [PATCH] net: skbuff: propagate shared-frag marker through
+ frag-transfer helpers
+
+commit 48f6a5356a33dd78e7144ae1faef95ffc990aae0 upstream.
+
+Two frag-transfer helpers (__pskb_copy_fclone() and skb_shift()) fail
+to propagate the SKBFL_SHARED_FRAG bit in skb_shinfo()->flags when
+moving frags from source to destination.  __pskb_copy_fclone() defers
+the rest of the shinfo metadata to skb_copy_header() after copying
+frag descriptors, but that helper only carries over gso_{size,segs,
+type} and never touches skb_shinfo()->flags; skb_shift() moves frag
+descriptors directly and leaves flags untouched.  As a result, the
+destination skb keeps a reference to the same externally-owned or
+page-cache-backed pages while reporting skb_has_shared_frag() as
+false.
+
+The mismatch is harmful in any in-place writer that uses
+skb_has_shared_frag() to decide whether shared pages must be detoured
+through skb_cow_data().  ESP input is one such writer (esp4.c,
+esp6.c), and a single nft 'dup to <local>' rule -- or any other
+nf_dup_ipv4() / xt_TEE caller -- is enough to land a pskb_copy()'d
+skb in esp_input() with the marker stripped, letting an unprivileged
+user write into the page cache of a root-owned read-only file via
+authencesn-ESN stray writes.
+
+Set SKBFL_SHARED_FRAG on the destination whenever frag descriptors
+were actually moved from the source.  skb_copy() and skb_copy_expand()
+share skb_copy_header() too but linearize all paged data into freshly
+allocated head storage and emerge with nr_frags == 0, so
+skb_has_shared_frag() returns false on its own; they need no change.
+
+The same omission exists in skb_gro_receive() and skb_gro_receive_list().
+The former moves the incoming skb's frag descriptors into the
+accumulator's last sub-skb via two paths (a direct frag-move loop and
+the head_frag + memcpy path); the latter chains the incoming skb whole
+onto p's frag_list.  Downstream skb_segment() reads only
+skb_shinfo(p)->flags, and skb_segment_list() reuses each sub-skb's
+shinfo as the nskb -- both p and lp must carry the marker.
+
+The same omission also exists in tcp_clone_payload(), which builds an
+MTU probe skb by moving frag descriptors from skbs on sk_write_queue
+into a freshly allocated nskb.  The helper falls into the same family
+and warrants the same fix for consistency; no TCP TX-side in-place
+writer is currently known to reach a user page through this gap, but
+a future consumer depending on the marker would regress silently.
+
+The same omission exists in skb_segment(): the per-iteration flag
+merge takes only head_skb's flag, and the inner switch that rebinds
+frag_skb to list_skb on head_skb-frags exhaustion does not fold the
+new frag_skb's flag into nskb.  Fold frag_skb's flag at both sites
+so segments drawing frags from frag_list members carry the marker.
+
+Fixes: cef401de7be8 ("net: fix possible wrong checksum generation")
+Fixes: f4c50a4034e6 ("xfrm: esp: avoid in-place decrypt on shared skb frags")
+Suggested-by: Sabrina Dubroca <sd@queasysnail.net>
+Suggested-by: Sultan Alsawaf <sultan@kerneltoast.com>
+Suggested-by: Ben Hutchings <ben@decadent.org.uk>
+Suggested-by: Lin Ma <malin89@huawei.com>
+Suggested-by: Jingguo Tan <tanjingguo@huawei.com>
+Suggested-by: Aaron Esau <aaron1esau@gmail.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Hyunwoo Kim <imv4bel@gmail.com>
+Tested-by: Rajat Gupta <rajat.gupta@oss.qualcomm.com>
+Link: https://patch.msgid.link/ageeJfJHwgzmKXbh@v4bel
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+[bwh: Backported to 5.10:
+ - Set the SKBTX_SHARED_FRAG flag in skb_shared_info::tx_flags,
+   instead of SKBFL_SHARED_FRAG in skb_shared_info::flags
+ - skb_gro_receive() and skb_gro_receive_list() are in skbuff.c here
+ - Drop change to tcp_clone_payload(), which does not exist here
+ - Adjust context in skb_shift()
+]
+Signed-off-by: Ben Hutchings <benh@debian.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit fbeab9555564a1b98e8582cd106dfe46c4606991)
+[quentin: Backport to 4.19:
+ - dropped changes to skb_gro_receive_list, which does not exist on v4.19,
+ added in 3a1296a38d0c ("net: Support GRO/GSO fraglist chaining.") (v5.6)
+]
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ net/core/skbuff.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/net/core/skbuff.c b/net/core/skbuff.c
+index e03afb7a1528..8032d5f851b5 100644
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -1412,6 +1412,7 @@ struct sk_buff *__pskb_copy_fclone(struct sk_buff *skb, int headroom,
+ 			skb_frag_ref(skb, i);
+ 		}
+ 		skb_shinfo(n)->nr_frags = i;
++		skb_shinfo(n)->tx_flags |= skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG;
+ 	}
+ 
+ 	if (skb_has_frag_list(skb)) {
+@@ -3202,6 +3203,8 @@ int skb_shift(struct sk_buff *tgt, struct sk_buff *skb, int shiftlen)
+ 	tgt->ip_summed = CHECKSUM_PARTIAL;
+ 	skb->ip_summed = CHECKSUM_PARTIAL;
+ 
++	skb_shinfo(tgt)->tx_flags |= skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG;
++
+ 	/* Yak, is it really working this way? Some helper please? */
+ 	skb->len -= shiftlen;
+ 	skb->data_len -= shiftlen;
+@@ -3688,7 +3691,8 @@ struct sk_buff *skb_segment(struct sk_buff *head_skb,
+ 		skb_copy_from_linear_data_offset(head_skb, offset,
+ 						 skb_put(nskb, hsize), hsize);
+ 
+-		skb_shinfo(nskb)->tx_flags |= skb_shinfo(head_skb)->tx_flags &
++		skb_shinfo(nskb)->tx_flags |= (skb_shinfo(head_skb)->tx_flags |
++					       skb_shinfo(frag_skb)->tx_flags) &
+ 					      SKBTX_SHARED_FRAG;
+ 
+ 		if (skb_orphan_frags(frag_skb, GFP_ATOMIC) ||
+@@ -3701,6 +3705,9 @@ struct sk_buff *skb_segment(struct sk_buff *head_skb,
+ 				nfrags = skb_shinfo(list_skb)->nr_frags;
+ 				frag = skb_shinfo(list_skb)->frags;
+ 				frag_skb = list_skb;
++
++				skb_shinfo(nskb)->tx_flags |= skb_shinfo(frag_skb)->tx_flags & SKBTX_SHARED_FRAG;
++
+ 				if (!skb_headlen(list_skb)) {
+ 					BUG_ON(!nfrags);
+ 				} else {
+@@ -3921,10 +3928,12 @@ int skb_gro_receive(struct sk_buff *p, struct sk_buff *skb)
+ 	p->data_len += len;
+ 	p->truesize += delta_truesize;
+ 	p->len += len;
++	skb_shinfo(p)->tx_flags |= skbinfo->tx_flags & SKBTX_SHARED_FRAG;
+ 	if (lp != p) {
+ 		lp->data_len += len;
+ 		lp->truesize += delta_truesize;
+ 		lp->len += len;
++		skb_shinfo(lp)->tx_flags |= skbinfo->tx_flags & SKBTX_SHARED_FRAG;
+ 	}
+ 	NAPI_GRO_CB(skb)->same_flow = 1;
+ 	return 0;

--- a/SOURCES/0006-net-rds-reset-op_nents-when-zerocopy-page-pin-fails.patch
+++ b/SOURCES/0006-net-rds-reset-op_nents-when-zerocopy-page-pin-fails.patch
@@ -1,0 +1,43 @@
+From 2b41c7d49261da21074553df058bd5131d267727 Mon Sep 17 00:00:00 2001
+From: Allison Henderson <achender@kernel.org>
+Date: Tue, 5 May 2026 16:43:36 -0700
+Subject: [PATCH] net/rds: reset op_nents when zerocopy page pin fails
+
+commit e174929793195e0cd6a4adb0cad731b39f9019b4 upstream.
+
+When iov_iter_get_pages2() fails in rds_message_zcopy_from_user(),
+the pinned pages are released with put_page(), and
+rm->data.op_mmp_znotifier is cleared.  But we fail to properly
+clear rm->data.op_nents.
+
+Later when rds_message_purge() is called from rds_sendmsg() the
+cleanup loop iterates over the incorrectly non zero number of
+op_nents and frees them again.
+
+Fix this by properly resetting op_nents when it should be in
+rds_message_zcopy_from_user().
+
+Fixes: 0cebaccef3ac ("rds: zerocopy Tx support.")
+Signed-off-by: Allison Henderson <achender@kernel.org>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260505234336.2132721-1-achender@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 9115669faedccdda100428e2d26fd0aac8c50799)
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ net/rds/message.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/net/rds/message.c b/net/rds/message.c
+index 4b00b1152a5f..cfb7cb4da7d0 100644
+--- a/net/rds/message.c
++++ b/net/rds/message.c
+@@ -393,6 +393,7 @@ static int rds_message_zcopy_from_user(struct rds_message *rm, struct iov_iter *
+ 
+ 			for (i = 0; i < rm->data.op_nents; i++)
+ 				put_page(sg_page(&rm->data.op_sg[i]));
++			rm->data.op_nents = 0;
+ 			mmp = &rm->data.op_mmp_znotifier->z_mmp;
+ 			mm_unaccount_pinned_pages(mmp);
+ 			ret = -EFAULT;

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.4%{?dist}
+Release: %{?xsrel}.5%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -735,8 +735,19 @@ Patch1003: 0001-ACPI-processor-idle-Check-acpi_bus_get_device-return.patch
 Patch1004: 0001-scsi-target-Fix-XCOPY-NAA-identifier-lookup.patch
 Patch1005: 0001-ext4-fix-off-by-one-error-in-do_split.patch
 Patch1006: 0001-SUNRPC-Restore-missing-call-to-cancel_work_sync.patch
+# CVE-2026-31431 (used by CopyFail v1)
 Patch1007: 0001-crypto-disable-authencesn-module-for-CVE-2026-31431.patch
+# CVE-2026-43284 (used by DirtyFrag, DirtyFail, CopyFail v2 Electric Boogaloo)
 Patch1008: 0001-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags.patch
+# CVE-2026-46333 (used by ssh-keysign-pwn, ptrace_may_dream)
+Patch1009: 0001-ptrace-restore-smp_rmb-in-__ptrace_may_access.patch
+Patch1010: 0002-ptrace-slightly-saner-get_dumpable-logic.patch
+Patch1011: 0003-kabi-ptrace-slightly-saner-get_dumpable-logic.patch
+# CVE-2026-46300 (used by fragnesia), iterative fixes to CVE-2026-43284
+Patch1012: 0004-net-skbuff-preserve-shared-frag-marker-during-coales.patch
+Patch1013: 0005-net-skbuff-propagate-shared-frag-marker-through-frag.patch
+# CVE-2026-43494 (used by pintheft)
+Patch1014: 0006-net-rds-reset-op_nents-when-zerocopy-page-pin-fails.patch
 
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
@@ -1091,6 +1102,11 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue May 26 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.5
+- Backport for CVE-2026-46300 (Fragnesia), iterative fixes to CVE-2026-43284
+- Backport for CVE-2026-46333 (ssh-key-sign, ptrace_may_dream)
+- Backport for CVE-2026-43494 (pintheft)
+
 * Wed May 13 2026 Yann Dirson <yann.dirson@vates.tech> - 4.19.19-8.0.46.4
 - Use short flag and short path to patch command to avoid overflowing a rpm limitation
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3322

#### Related changes (optional)

N/A

#### Context & Motivation

Our dom0 is vulnerable to various public exploits that have been released in the last few days.  This PR tries to address them.

Source code review: https://github.com/xcp-ng/linux/pull/4

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

With the next update train.

---

### Release Notes and Documentation

#### Explain the change to users

CVE-2026-46300:  A logic error in the network stack could allow an unprivileged local user to escalate its privileges to root by modifying page caches for file-backed files that were not supposed to be writable.  The modifications are not persistent to a reboot (i.e. no disk corruption).  This vulnerability is used by the public exploit [Fragnesia](https://github.com/v12-security/pocs/tree/main/fragnesia).

CVE-2026-46333: Incorrect tracking of users privilege level when a task is exiting in the ptrace sub-system could allow an unprivileged local user to escalate its privileges to root by writing to file descriptors they are not supposed to have access to.  The changes made to potentially root-owned files are persisted across reboots.  This vulnerability is used by the public exploits [ssh-keysign-pwn](https://github.com/0xdeadbeefnetwork/ssh-keysign-pwn) as well as [ptrace_may_dream](https://github.com/sgkdev/ptrace_may_dream).

CVE-2026-43494: A double-free of pinned pages in the RDS kernel module in the transmit error path could allow an unprivileged local user to escalate its privileges to root by modifying page caches for file-backed files, allowing them to for example overwrite a SUID binary in page cache with a shellcode.  Changes are not persistent across reboots.  This vulnerability is used by the public exploit [pintheft](https://github.com/v12-security/pocs/tree/main/pintheft).

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

EXPLANATIONS

N/A.

---

### Testing and regression avoidance

#### What tests have you performed?

None, regular CI should be fine for assessing regressions.

#### What manual tests should be performed after the build, and by whom?

None.  Note that none of the public exploits work as is on XCP-ng 9 due to some kernel API being missing, but the vulnerable code paths still exist and could be reachable through other ways.  As such we can't use the public exploits to verify patch correctness.

#### What's covered by the xcp-ng-tests test suite?

Regular regression tests.

#### What tests have been or will be added to CI for this change? If none, explain why.

None.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
