### PR TITLE
Add fix for CVE-2026-46243

### DIFF
--- a/SOURCES/0007-smb-client-reject-userspace-cifs-spnego-descriptions.patch
+++ b/SOURCES/0007-smb-client-reject-userspace-cifs-spnego-descriptions.patch
@@ -1,0 +1,74 @@
+From 7713bd320ed4fc3d08a227cd8e41242219a16981 Mon Sep 17 00:00:00 2001
+From: Asim Viladi Oglu Manizada <manizada@pm.me>
+Date: Sat, 16 May 2026 21:15:39 +0000
+Subject: smb: client: reject userspace cifs.spnego descriptions
+
+commit 3da1fdf4efbc490041eb4f836bf596201203f8f2 upstream.
+
+cifs.spnego key descriptions contain authority-bearing fields such as
+pid, uid, creduid, and upcall_target that cifs.upcall treats as
+kernel-originating inputs. However, userspace can also create keys of
+this type through request_key(2) or add_key(2), allowing those fields to
+be supplied without CIFS origin.
+
+Only accept cifs.spnego descriptions while CIFS is using its private
+spnego_cred to request the key.
+
+Fixes: f1d662a7d5e5 ("[CIFS] Add upcall files for cifs to use spnego/kerberos")
+Assisted-by: avom-custom-harness:gpt-5.5-qwen3.6-mod-mix
+Reviewed-by: David Howells <dhowells@redhat.com>
+Signed-off-by: Asim Viladi Oglu Manizada <manizada@pm.me>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+[Salvatore Bonaccorso: Apply changes to fs/cifs/cifs_spnego.c instead of
+fs/smb/client/cifs_spnego.c before 38c8a9a52082 ("smb: move client and server
+files to common directory fs/smb") in v6.4-rc1 and backported to v6.1.36]
+Signed-off-by: Salvatore Bonaccorso <carnil@debian.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ fs/cifs/cifs_spnego.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/fs/cifs/cifs_spnego.c b/fs/cifs/cifs_spnego.c
+index 4f9d08ac9dde5..5b7614451033b 100644
+--- a/fs/cifs/cifs_spnego.c
++++ b/fs/cifs/cifs_spnego.c
+@@ -20,6 +20,7 @@
+  */
+ 
+ #include <linux/list.h>
++#include <linux/cred.h>
+ #include <linux/slab.h>
+ #include <linux/string.h>
+ #include <keys/user-type.h>
+@@ -58,12 +59,27 @@ cifs_spnego_key_destroy(struct key *key)
+ 	kfree(key->payload.data[0]);
+ }
+ 
++static int
++cifs_spnego_key_vet_description(const char *description)
++{
++	/*
++	 * cifs.spnego descriptions are authority-bearing inputs to cifs.upcall.
++	 * They are only valid when produced by CIFS while using the private
++	 * spnego_cred installed below.  Do not let userspace create this type
++	 * of key through request_key(2)/add_key(2), since the helper treats
++	 * pid/uid/creduid/upcall_target as kernel-originating fields.
++	 */
++	if (current_cred() != spnego_cred)
++		return -EPERM;
++	return 0;
++}
+ 
+ /*
+  * keytype for CIFS spnego keys
+  */
+ struct key_type cifs_spnego_key_type = {
+ 	.name		= "cifs.spnego",
++	.vet_description = cifs_spnego_key_vet_description,
+ 	.instantiate	= cifs_spnego_key_instantiate,
+ 	.destroy	= cifs_spnego_key_destroy,
+ 	.describe	= user_describe,
+-- 
+cgit 1.3-korg
+

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.5%{?dist}
+Release: %{?xsrel}.6%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -748,6 +748,8 @@ Patch1012: 0004-net-skbuff-preserve-shared-frag-marker-during-coales.patch
 Patch1013: 0005-net-skbuff-propagate-shared-frag-marker-through-frag.patch
 # CVE-2026-43494 (used by pintheft)
 Patch1014: 0006-net-rds-reset-op_nents-when-zerocopy-page-pin-fails.patch
+# CVE-2026-46243 (cifswitch)
+Patch1015: 0007-smb-client-reject-userspace-cifs-spnego-descriptions.patch
 
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
@@ -1102,6 +1104,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Wed Jun 03 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 4.19.19-8.0.46.6
+- Backport for CVE-2026-46243 (cifswitch)
+
 * Tue May 26 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.5
 - Backport for CVE-2026-46300 (Fragnesia), iterative fixes to CVE-2026-43284
 - Backport for CVE-2026-46333 (ssh-key-sign, ptrace_may_dream)


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3370

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Our dom0 is vulnerable to the public exploit of this CVE. This PR tries to address them.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

It should be next (because it's a security update)

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

CVE-2026-46243: ~~In the Linux kernel, the following vulnerability has been resolved: smb: client: reject userspace cifs.spnego descriptions cifs.spnego key descriptions contain authority-bearing fields such as pid, uid, creduid, and upcall_target that cifs.upcall treats as kernel-originating inputs. However, userspace can also create keys of this type through request_key(2) or add_key(2), allowing those fields to be supplied without CIFS origin. Only accept cifs.spnego descriptions while CIFS is using its private spnego_cred to request the key.~~ Fixed the CIFSwitch security vulnerability that could allow privilege escalation from a user with low privileges.


#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

~~N/A~~ No functionnal changees (It's only a security update)

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

I only verified that the fix corrected the vulnerability by modifying the exploit.
No other test have been performed.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

~~None~~ Setting up SMB shares would allow verification that its operation is guaranteed.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

~~None~~ XCP-ng-tests already connect to a shared smb (ISO & VDI)

#### What tests have been or will be added to CI for this change? If none, explain why.

~~None~~ None, because there is already some test (connection to a shared SMB (ISO & VDI)

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
