### PR TITLE
8.3: Backport fixes in pcieport driver for hotplug hardware detection

### DIFF
--- a/SOURCES/0001-PCI-pciehp-Differentiate-between-surprise-and-safe-r.patch
+++ b/SOURCES/0001-PCI-pciehp-Differentiate-between-surprise-and-safe-r.patch
@@ -1,0 +1,201 @@
+From 1ca654f73ce93962521c194c5a24abc32d24a3b4 Mon Sep 17 00:00:00 2001
+From: Lukas Wunner <lukas@wunner.de>
+Date: Tue, 31 Jul 2018 07:50:37 +0200
+Subject: PCI: pciehp: Differentiate between surprise and safe removal
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+When removing PCI devices below a hotplug bridge, pciehp marks them as
+disconnected if the card is no longer present in the slot or it quiesces
+them if the card is still present (by disabling INTx interrupts, bus
+mastering and SERR# reporting).
+
+To detect whether the card is still present, pciehp checks the Presence
+Detect State bit in the Slot Status register.  The problem with this
+approach is that even if the card is present, the link to it may be
+down, and it that case it would be better to mark the devices as
+disconnected instead of trying to quiesce them.  Moreover, if the card
+in the slot was quickly replaced by another one, the Presence Detect
+State bit would be set, yet trying to quiesce the new card's devices
+would be wrong and the correct thing to do is to mark the previous
+card's devices as disconnected.
+
+Instead of looking at the Presence Detect State bit, it is better to
+differentiate whether the card was surprise removed versus safely
+removed (via sysfs or an Attention Button press).  On surprise removal,
+the devices should be marked as disconnected, whereas on safe removal it
+is correct to quiesce the devices.
+
+The knowledge whether a surprise removal or a safe removal is at hand
+does exist further up in the call stack:  A surprise removal is
+initiated by pciehp_handle_presence_or_link_change(), a safe removal by
+pciehp_handle_disable_request().
+
+Pass that information down to pciehp_unconfigure_device() and use it in
+lieu of the Presence Detect State bit.  While there, add kernel-doc to
+pciehp_unconfigure_device() and pciehp_configure_device().
+
+Tested-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Signed-off-by: Lukas Wunner <lukas@wunner.de>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Cc: Keith Busch <keith.busch@intel.com>
+
+(cherry picked from commit 11e87702be65780be92fb1f0a5b7b293954185f7)
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+No conflict
+---
+ drivers/pci/hotplug/pciehp.h      |  2 +-
+ drivers/pci/hotplug/pciehp_ctrl.c | 22 +++++++++++++---------
+ drivers/pci/hotplug/pciehp_pci.c  | 23 ++++++++++++++++++++---
+ 3 files changed, 34 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/pci/hotplug/pciehp.h b/drivers/pci/hotplug/pciehp.h
+index 811cf83f956de..39c9c8815a355 100644
+--- a/drivers/pci/hotplug/pciehp.h
++++ b/drivers/pci/hotplug/pciehp.h
+@@ -181,7 +181,7 @@ void pciehp_handle_button_press(struct slot *slot);
+ void pciehp_handle_disable_request(struct slot *slot);
+ void pciehp_handle_presence_or_link_change(struct slot *slot, u32 events);
+ int pciehp_configure_device(struct slot *p_slot);
+-void pciehp_unconfigure_device(struct slot *p_slot);
++void pciehp_unconfigure_device(struct slot *p_slot, bool presence);
+ void pciehp_queue_pushbutton_work(struct work_struct *work);
+ struct controller *pcie_init(struct pcie_device *dev);
+ int pcie_init_notification(struct controller *ctrl);
+diff --git a/drivers/pci/hotplug/pciehp_ctrl.c b/drivers/pci/hotplug/pciehp_ctrl.c
+index da7c72372ffcf..c283253d2cd78 100644
+--- a/drivers/pci/hotplug/pciehp_ctrl.c
++++ b/drivers/pci/hotplug/pciehp_ctrl.c
+@@ -26,6 +26,9 @@
+    hotplug controller logic
+  */
+ 
++#define SAFE_REMOVAL	 true
++#define SURPRISE_REMOVAL false
++
+ static void set_slot_off(struct controller *ctrl, struct slot *pslot)
+ {
+ 	/* turn off slot, turn on Amber LED, turn off Green LED if supported*/
+@@ -101,12 +104,13 @@ static int board_added(struct slot *p_slot)
+ /**
+  * remove_board - Turns off slot and LEDs
+  * @p_slot: slot where board is being removed
++ * @safe_removal: whether the board is safely removed (versus surprise removed)
+  */
+-static void remove_board(struct slot *p_slot)
++static void remove_board(struct slot *p_slot, bool safe_removal)
+ {
+ 	struct controller *ctrl = p_slot->ctrl;
+ 
+-	pciehp_unconfigure_device(p_slot);
++	pciehp_unconfigure_device(p_slot, safe_removal);
+ 
+ 	if (POWER_CTRL(ctrl)) {
+ 		pciehp_power_off_slot(p_slot);
+@@ -124,7 +128,7 @@ static void remove_board(struct slot *p_slot)
+ }
+ 
+ static int pciehp_enable_slot(struct slot *slot);
+-static int pciehp_disable_slot(struct slot *slot);
++static int pciehp_disable_slot(struct slot *slot, bool safe_removal);
+ 
+ void pciehp_request(struct controller *ctrl, int action)
+ {
+@@ -216,7 +220,7 @@ void pciehp_handle_disable_request(struct slot *slot)
+ 	slot->state = POWEROFF_STATE;
+ 	mutex_unlock(&slot->lock);
+ 
+-	ctrl->request_result = pciehp_disable_slot(slot);
++	ctrl->request_result = pciehp_disable_slot(slot, SAFE_REMOVAL);
+ }
+ 
+ void pciehp_handle_presence_or_link_change(struct slot *slot, u32 events)
+@@ -243,7 +247,7 @@ void pciehp_handle_presence_or_link_change(struct slot *slot, u32 events)
+ 		if (events & PCI_EXP_SLTSTA_PDC)
+ 			ctrl_info(ctrl, "Slot(%s): Card not present\n",
+ 				  slot_name(slot));
+-		pciehp_disable_slot(slot);
++		pciehp_disable_slot(slot, SURPRISE_REMOVAL);
+ 		break;
+ 	default:
+ 		mutex_unlock(&slot->lock);
+@@ -329,7 +333,7 @@ static int pciehp_enable_slot(struct slot *slot)
+ 	return ret;
+ }
+ 
+-static int __pciehp_disable_slot(struct slot *p_slot)
++static int __pciehp_disable_slot(struct slot *p_slot, bool safe_removal)
+ {
+ 	u8 getstatus = 0;
+ 	struct controller *ctrl = p_slot->ctrl;
+@@ -343,17 +347,17 @@ static int __pciehp_disable_slot(struct slot *p_slot)
+ 		}
+ 	}
+ 
+-	remove_board(p_slot);
++	remove_board(p_slot, safe_removal);
+ 	return 0;
+ }
+ 
+-static int pciehp_disable_slot(struct slot *slot)
++static int pciehp_disable_slot(struct slot *slot, bool safe_removal)
+ {
+ 	struct controller *ctrl = slot->ctrl;
+ 	int ret;
+ 
+ 	pm_runtime_get_sync(&ctrl->pcie->port->dev);
+-	ret = __pciehp_disable_slot(slot);
++	ret = __pciehp_disable_slot(slot, safe_removal);
+ 	pm_runtime_put(&ctrl->pcie->port->dev);
+ 
+ 	mutex_lock(&slot->lock);
+diff --git a/drivers/pci/hotplug/pciehp_pci.c b/drivers/pci/hotplug/pciehp_pci.c
+index a32023afa25bc..642b57c4e0b69 100644
+--- a/drivers/pci/hotplug/pciehp_pci.c
++++ b/drivers/pci/hotplug/pciehp_pci.c
+@@ -20,6 +20,14 @@
+ #include "../pci.h"
+ #include "pciehp.h"
+ 
++/**
++ * pciehp_configure_device() - enumerate PCI devices below a hotplug bridge
++ * @p_slot: PCIe hotplug slot
++ *
++ * Enumerate PCI devices below a hotplug bridge and add them to the system.
++ * Return 0 on success, %-EEXIST if the devices are already enumerated or
++ * %-ENODEV if enumeration failed.
++ */
+ int pciehp_configure_device(struct slot *p_slot)
+ {
+ 	struct pci_dev *dev;
+@@ -69,9 +77,19 @@ int pciehp_configure_device(struct slot *p_slot)
+ 	return ret;
+ }
+ 
+-void pciehp_unconfigure_device(struct slot *p_slot)
++/**
++ * pciehp_unconfigure_device() - remove PCI devices below a hotplug bridge
++ * @p_slot: PCIe hotplug slot
++ * @presence: whether the card is still present in the slot;
++ *	true for safe removal via sysfs or an Attention Button press,
++ *	false for surprise removal
++ *
++ * Unbind PCI devices below a hotplug bridge from their drivers and remove
++ * them from the system.  Safely removed devices are quiesced.  Surprise
++ * removed devices are marked as such to prevent further accesses.
++ */
++void pciehp_unconfigure_device(struct slot *p_slot, bool presence)
+ {
+-	u8 presence = 0;
+ 	struct pci_dev *dev, *temp;
+ 	struct pci_bus *parent = p_slot->ctrl->pcie->port->subordinate;
+ 	u16 command;
+@@ -79,7 +97,6 @@ void pciehp_unconfigure_device(struct slot *p_slot)
+ 
+ 	ctrl_dbg(ctrl, "%s: domain:bus:dev = %04x:%02x:00\n",
+ 		 __func__, pci_domain_nr(parent), parent->number);
+-	pciehp_get_adapter_status(p_slot, &presence);
+ 
+ 	pci_lock_rescan_remove();
+ 

--- a/SOURCES/0001-PCI-pciehp-Disable-in-band-presence-detect-when-poss.patch
+++ b/SOURCES/0001-PCI-pciehp-Disable-in-band-presence-detect-when-poss.patch
@@ -1,0 +1,128 @@
+From 88cb09000d8044bf3c447629e60c8d781ddaef30 Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Fri, 25 Oct 2019 15:00:45 -0400
+Subject: PCI: pciehp: Disable in-band presence detect when possible
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+The presence detect state (PDS) is normally a logical OR of in-band and
+out-of-band (OOB) presence detect.  As of PCIe 4.0, there is the option to
+disable in-band presence so that the PDS bit always reflects the state of
+the out-of-band presence.
+
+The recommendation of the PCIe spec is to disable in-band presence whenever
+supported (PCIe r5.0, appendix I implementation note):
+
+  Due to architectural issues, the in-band (Physical-Layer-based) portion
+  of the PD mechanism is deprecated for use with async hot-plug. One issue
+  is that in-band PD as architected does not detect adapter removal during
+  certain LTSSM states, notably the L1 and Disabled States.  Another issue
+  is that when both in-band and OOB PD are being used together, the
+  Presence Detect State bit and its associated interrupt mechanism always
+  reflect the logical OR of the inband and OOB PD states, and with some
+  hot-plug hardware configurations, it is important for software to detect
+  and respond to in-band and OOB PD events independently.  If OOB PD is
+  being used and the associated DSP supports In-Band PD Disable, it is
+  recommended that the In-Band PD Disable bit be Set, and the Presence
+  Detect State bit and its associated interrupt mechanism be used
+  exclusively for OOB PD.  As a substitute for in-band PD with async
+  hot-plug, the reference model uses either the DPC or the DLL Link Active
+  mechanism.
+
+Link: https://lore.kernel.org/r/20191025190047.38130-2-stuart.w.hayes@gmail.com
+[bhelgaas: move PCI_EXP_SLTCAP2 read earlier & print PCI_EXP_SLTCAP2_IBPD
+value (suggested by Lukas)]
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Reviewed-by: Andy Shevchenko <andy.shevchenko@gmail.com>
+Reviewed-by: Lukas Wunner <lukas@wunner.de>
+(cherry picked from commit 202853595e53f981c86656c49fc1cc1e3620f558)
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Backport notes:
+ Move the inband_presence_disabled field at the bottom of the controller
+ structure for conflict resolution. Since fields have been shuffled in
+ this structure by previous commits, there was no obvious place for it
+ so I arbitrary put it at the bottom.
+---
+ drivers/pci/hotplug/pciehp.h     |  1 +
+ drivers/pci/hotplug/pciehp_hpc.c | 12 ++++++++++--
+ include/uapi/linux/pci_regs.h    |  2 ++
+ 3 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pci/hotplug/pciehp.h b/drivers/pci/hotplug/pciehp.h
+index a4b294fddc939..fbb908d7f094c 100644
+--- a/drivers/pci/hotplug/pciehp.h
++++ b/drivers/pci/hotplug/pciehp.h
+@@ -127,6 +127,7 @@ struct controller {
+ 	atomic_t pending_events;
+ 	int request_result;
+ 	wait_queue_head_t requester;
++	unsigned int inband_presence_disabled:1;
+ };
+ 
+ /**
+diff --git a/drivers/pci/hotplug/pciehp_hpc.c b/drivers/pci/hotplug/pciehp_hpc.c
+index 61a2e2c0e217b..c7e27d871de2d 100644
+--- a/drivers/pci/hotplug/pciehp_hpc.c
++++ b/drivers/pci/hotplug/pciehp_hpc.c
+@@ -870,7 +870,7 @@ static inline void dbg_ctrl(struct controller *ctrl)
+ struct controller *pcie_init(struct pcie_device *dev)
+ {
+ 	struct controller *ctrl;
+-	u32 slot_cap, link_cap;
++	u32 slot_cap, slot_cap2, link_cap;
+ 	u8 poweron;
+ 	struct pci_dev *pdev = dev->port;
+ 
+@@ -898,6 +898,13 @@ struct controller *pcie_init(struct pcie_device *dev)
+ 	init_waitqueue_head(&ctrl->queue);
+ 	dbg_ctrl(ctrl);
+ 
++	pcie_capability_read_dword(pdev, PCI_EXP_SLTCAP2, &slot_cap2);
++	if (slot_cap2 & PCI_EXP_SLTCAP2_IBPD) {
++		pcie_write_cmd_nowait(ctrl, PCI_EXP_SLTCTL_IBPD_DISABLE,
++				      PCI_EXP_SLTCTL_IBPD_DISABLE);
++		ctrl->inband_presence_disabled = 1;
++	}
++
+ 	/* Check if Data Link Layer Link Active Reporting is implemented */
+ 	pcie_capability_read_dword(pdev, PCI_EXP_LNKCAP, &link_cap);
+ 	if (link_cap & PCI_EXP_LNKCAP_DLLLARC)
+@@ -909,7 +916,7 @@ struct controller *pcie_init(struct pcie_device *dev)
+ 		PCI_EXP_SLTSTA_MRLSC | PCI_EXP_SLTSTA_CC |
+ 		PCI_EXP_SLTSTA_DLLSC | PCI_EXP_SLTSTA_PDC);
+ 
+-	ctrl_info(ctrl, "Slot #%d AttnBtn%c PwrCtrl%c MRL%c AttnInd%c PwrInd%c HotPlug%c Surprise%c Interlock%c NoCompl%c LLActRep%c%s\n",
++	ctrl_info(ctrl, "Slot #%d AttnBtn%c PwrCtrl%c MRL%c AttnInd%c PwrInd%c HotPlug%c Surprise%c Interlock%c NoCompl%c IbPresDis%c LLActRep%c%s\n",
+ 		(slot_cap & PCI_EXP_SLTCAP_PSN) >> 19,
+ 		FLAG(slot_cap, PCI_EXP_SLTCAP_ABP),
+ 		FLAG(slot_cap, PCI_EXP_SLTCAP_PCP),
+@@ -920,6 +927,7 @@ struct controller *pcie_init(struct pcie_device *dev)
+ 		FLAG(slot_cap, PCI_EXP_SLTCAP_HPS),
+ 		FLAG(slot_cap, PCI_EXP_SLTCAP_EIP),
+ 		FLAG(slot_cap, PCI_EXP_SLTCAP_NCCS),
++		FLAG(slot_cap2, PCI_EXP_SLTCAP2_IBPD),
+ 		FLAG(link_cap, PCI_EXP_LNKCAP_DLLLARC),
+ 		pdev->broken_cmd_compl ? " (with Cmd Compl erratum)" : "");
+ 
+diff --git a/include/uapi/linux/pci_regs.h b/include/uapi/linux/pci_regs.h
+index ee556ccc93f48..46711a1897a3c 100644
+--- a/include/uapi/linux/pci_regs.h
++++ b/include/uapi/linux/pci_regs.h
+@@ -596,6 +596,7 @@
+ #define  PCI_EXP_SLTCTL_PWR_OFF        0x0400 /* Power Off */
+ #define  PCI_EXP_SLTCTL_EIC	0x0800	/* Electromechanical Interlock Control */
+ #define  PCI_EXP_SLTCTL_DLLSCE	0x1000	/* Data Link Layer State Changed Enable */
++#define  PCI_EXP_SLTCTL_IBPD_DISABLE	0x4000 /* In-band PD disable */
+ #define PCI_EXP_SLTSTA		26	/* Slot Status */
+ #define  PCI_EXP_SLTSTA_ABP	0x0001	/* Attention Button Pressed */
+ #define  PCI_EXP_SLTSTA_PFD	0x0002	/* Power Fault Detected */
+@@ -666,6 +667,7 @@
+ #define PCI_EXP_LNKSTA2		50	/* Link Status 2 */
+ #define PCI_CAP_EXP_ENDPOINT_SIZEOF_V2	52	/* v2 endpoints with link end here */
+ #define PCI_EXP_SLTCAP2		52	/* Slot Capabilities 2 */
++#define  PCI_EXP_SLTCAP2_IBPD	0x00000001 /* In-band PD Disable Supported */
+ #define PCI_EXP_SLTCTL2		56	/* Slot Control 2 */
+ #define PCI_EXP_SLTSTA2		58	/* Slot Status 2 */
+ 

--- a/SOURCES/0002-PCI-pciehp-Tolerate-Presence-Detect-hardwired-to-zer.patch
+++ b/SOURCES/0002-PCI-pciehp-Tolerate-Presence-Detect-hardwired-to-zer.patch
@@ -1,0 +1,200 @@
+From faf6e731ded45dfa2269bf17a76406940845fb18 Mon Sep 17 00:00:00 2001
+From: Lukas Wunner <lukas@wunner.de>
+Date: Sat, 8 Sep 2018 09:59:01 +0200
+Subject: PCI: pciehp: Tolerate Presence Detect hardwired to zero
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+The WiGig Bus Extension (WBE) specification allows tunneling PCIe over
+IEEE 802.11.  A product implementing this spec is the wil6210 from
+Wilocity (now part of Qualcomm Atheros).  It integrates a PCIe switch
+with a wireless network adapter:
+
+  00.0-+              [1ae9:0101]  Upstream Port
+       +-00.0-+       [1ae9:0200]  Downstream Port
+       |      +-00.0  [168c:0034]  Atheros AR9462 Wireless Network
+Adapter
+       +-02.0         [1ae9:0201]  Downstream Port
+       +-03.0         [1ae9:0201]  Downstream Port
+
+Wirelessly attached devices presumably appear below the hotplug ports
+with device ID [1ae9:0201].  Oddly, the Downstream Port [1ae9:0200]
+leading to the wireless network adapter is likewise Hotplug Capable,
+but has its Presence Detect State bit hardwired to zero.  Even if the
+Link Active bit is set, Presence Detect is zero, so this cannot be
+caused by in-band presence detection but only by broken hardware.
+
+pciehp assumes an empty slot if Presence Detect State is zero,
+regardless of Link Active being one.  Consequently, up until v4.18 it
+removes the wireless network adapter in pciehp_resume().  From v4.19 it
+already does so in pciehp_probe().
+
+Be lenient towards broken hardware and assume the slot is occupied if
+Link Active is set:  Introduce pciehp_card_present_or_link_active()
+and use it in lieu of pciehp_get_adapter_status() everywhere, except
+in pciehp_handle_presence_or_link_change() whose log messages depend
+on which of Presence Detect State or Link Active is set.
+
+Remove the Presence Detect State check from __pciehp_enable_slot()
+because it is only called if either of Presence Detect State or Link
+Active is set.
+
+Caution: There is a possibility that broken hardware exists which has
+working Presence Detect but hardwires Link Active to one.  On such
+hardware the slot will now incorrectly be considered always occupied.
+If such hardware is discovered, this commit can be rolled back and a
+quirk can be added which sets is_hotplug_bridge = 0 for [1ae9:0200].
+
+Link: https://bugzilla.kernel.org/show_bug.cgi?id=200839
+Reported-and-tested-by: David Yang <mmyangfl@gmail.com>
+Signed-off-by: Lukas Wunner <lukas@wunner.de>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Cc: Rajat Jain <rajatja@google.com>
+Cc: Ashok Raj <ashok.raj@intel.com>
+
+(cherry picked from commit 80696f991424d05a784c0cf9c314ac09ac280406)
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+No conflict
+---
+ drivers/pci/hotplug/pciehp.h      |  3 ++-
+ drivers/pci/hotplug/pciehp_core.c |  6 +++---
+ drivers/pci/hotplug/pciehp_ctrl.c | 10 ++--------
+ drivers/pci/hotplug/pciehp_hpc.c  | 25 +++++++++++++++++++------
+ 4 files changed, 26 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/pci/hotplug/pciehp.h b/drivers/pci/hotplug/pciehp.h
+index 39c9c8815a355..a4b294fddc939 100644
+--- a/drivers/pci/hotplug/pciehp.h
++++ b/drivers/pci/hotplug/pciehp.h
+@@ -194,11 +194,12 @@ void pciehp_get_attention_status(struct slot *slot, u8 *status);
+ 
+ void pciehp_set_attention_status(struct slot *slot, u8 status);
+ void pciehp_get_latch_status(struct slot *slot, u8 *status);
+-void pciehp_get_adapter_status(struct slot *slot, u8 *status);
+ int pciehp_query_power_fault(struct slot *slot);
+ void pciehp_green_led_on(struct slot *slot);
+ void pciehp_green_led_off(struct slot *slot);
+ void pciehp_green_led_blink(struct slot *slot);
++bool pciehp_card_present(struct controller *ctrl);
++bool pciehp_card_present_or_link_active(struct controller *ctrl);
+ int pciehp_check_link_status(struct controller *ctrl);
+ bool pciehp_check_link_active(struct controller *ctrl);
+ void pciehp_release_ctrl(struct controller *ctrl);
+diff --git a/drivers/pci/hotplug/pciehp_core.c b/drivers/pci/hotplug/pciehp_core.c
+index ec48c9433ae50..fddd376f9e9b4 100644
+--- a/drivers/pci/hotplug/pciehp_core.c
++++ b/drivers/pci/hotplug/pciehp_core.c
+@@ -188,7 +188,7 @@ static int get_adapter_status(struct hotplug_slot *hotplug_slot, u8 *value)
+ 	struct pci_dev *pdev = slot->ctrl->pcie->port;
+ 
+ 	pci_config_pm_runtime_get(pdev);
+-	pciehp_get_adapter_status(slot, value);
++	*value = pciehp_card_present_or_link_active(slot->ctrl);
+ 	pci_config_pm_runtime_put(pdev);
+ 	return 0;
+ }
+@@ -213,12 +213,12 @@ static int reset_slot(struct hotplug_slot *hotplug_slot, int probe)
+ static void pciehp_check_presence(struct controller *ctrl)
+ {
+ 	struct slot *slot = ctrl->slot;
+-	u8 occupied;
++	bool occupied;
+ 
+ 	down_read(&ctrl->reset_lock);
+ 	mutex_lock(&slot->lock);
+ 
+-	pciehp_get_adapter_status(slot, &occupied);
++	occupied = pciehp_card_present_or_link_active(ctrl);
+ 	if ((occupied && (slot->state == OFF_STATE ||
+ 			  slot->state == BLINKINGON_STATE)) ||
+ 	    (!occupied && (slot->state == ON_STATE ||
+diff --git a/drivers/pci/hotplug/pciehp_ctrl.c b/drivers/pci/hotplug/pciehp_ctrl.c
+index c283253d2cd78..1fb9ba0ac3a53 100644
+--- a/drivers/pci/hotplug/pciehp_ctrl.c
++++ b/drivers/pci/hotplug/pciehp_ctrl.c
+@@ -226,8 +226,7 @@ void pciehp_handle_disable_request(struct slot *slot)
+ void pciehp_handle_presence_or_link_change(struct slot *slot, u32 events)
+ {
+ 	struct controller *ctrl = slot->ctrl;
+-	bool link_active;
+-	u8 present;
++	bool present, link_active;
+ 
+ 	/*
+ 	 * If the slot is on and presence or link has changed, turn it off.
+@@ -256,7 +255,7 @@ void pciehp_handle_presence_or_link_change(struct slot *slot, u32 events)
+ 
+ 	/* Turn the slot on if it's occupied or link is up */
+ 	mutex_lock(&slot->lock);
+-	pciehp_get_adapter_status(slot, &present);
++	present = pciehp_card_present(ctrl);
+ 	link_active = pciehp_check_link_active(ctrl);
+ 	if (!present && !link_active) {
+ 		mutex_unlock(&slot->lock);
+@@ -289,11 +288,6 @@ static int __pciehp_enable_slot(struct slot *p_slot)
+ 	u8 getstatus = 0;
+ 	struct controller *ctrl = p_slot->ctrl;
+ 
+-	pciehp_get_adapter_status(p_slot, &getstatus);
+-	if (!getstatus) {
+-		ctrl_info(ctrl, "Slot(%s): No adapter\n", slot_name(p_slot));
+-		return -ENODEV;
+-	}
+ 	if (MRL_SENS(p_slot->ctrl)) {
+ 		pciehp_get_latch_status(p_slot, &getstatus);
+ 		if (getstatus) {
+diff --git a/drivers/pci/hotplug/pciehp_hpc.c b/drivers/pci/hotplug/pciehp_hpc.c
+index a938abdb41cee..61a2e2c0e217b 100644
+--- a/drivers/pci/hotplug/pciehp_hpc.c
++++ b/drivers/pci/hotplug/pciehp_hpc.c
+@@ -389,13 +389,27 @@ void pciehp_get_latch_status(struct slot *slot, u8 *status)
+ 	*status = !!(slot_status & PCI_EXP_SLTSTA_MRLSS);
+ }
+ 
+-void pciehp_get_adapter_status(struct slot *slot, u8 *status)
++bool pciehp_card_present(struct controller *ctrl)
+ {
+-	struct pci_dev *pdev = ctrl_dev(slot->ctrl);
++	struct pci_dev *pdev = ctrl_dev(ctrl);
+ 	u16 slot_status;
+ 
+ 	pcie_capability_read_word(pdev, PCI_EXP_SLTSTA, &slot_status);
+-	*status = !!(slot_status & PCI_EXP_SLTSTA_PDS);
++	return slot_status & PCI_EXP_SLTSTA_PDS;
++}
++
++/**
++ * pciehp_card_present_or_link_active() - whether given slot is occupied
++ * @ctrl: PCIe hotplug controller
++ *
++ * Unlike pciehp_card_present(), which determines presence solely from the
++ * Presence Detect State bit, this helper also returns true if the Link Active
++ * bit is set.  This is a concession to broken hotplug ports which hardwire
++ * Presence Detect State to zero, such as Wilocity's [1ae9:0200].
++ */
++bool pciehp_card_present_or_link_active(struct controller *ctrl)
++{
++	return pciehp_card_present(ctrl) || pciehp_check_link_active(ctrl);
+ }
+ 
+ int pciehp_query_power_fault(struct slot *slot)
+@@ -857,7 +871,7 @@ struct controller *pcie_init(struct pcie_device *dev)
+ {
+ 	struct controller *ctrl;
+ 	u32 slot_cap, link_cap;
+-	u8 occupied, poweron;
++	u8 poweron;
+ 	struct pci_dev *pdev = dev->port;
+ 
+ 	ctrl = kzalloc(sizeof(*ctrl), GFP_KERNEL);
+@@ -917,9 +931,8 @@ struct controller *pcie_init(struct pcie_device *dev)
+ 	 * requested yet, so avoid triggering a notification with this command.
+ 	 */
+ 	if (POWER_CTRL(ctrl)) {
+-		pciehp_get_adapter_status(ctrl->slot, &occupied);
+ 		pciehp_get_power_status(ctrl->slot, &poweron);
+-		if (!occupied && poweron) {
++		if (!pciehp_card_present_or_link_active(ctrl) && poweron) {
+ 			pcie_disable_notification(ctrl);
+ 			pciehp_power_off_slot(ctrl->slot);
+ 		}

--- a/SOURCES/0002-PCI-pciehp-Wait-for-PDS-if-in-band-presence-is-disab.patch
+++ b/SOURCES/0002-PCI-pciehp-Wait-for-PDS-if-in-band-presence-is-disab.patch
@@ -1,0 +1,71 @@
+From ab77403487ce82e253d80f9d07715d419956877f Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Fri, 25 Oct 2019 15:00:46 -0400
+Subject: PCI: pciehp: Wait for PDS if in-band presence is disabled
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+When in-band presence detect is disabled, PDS may come up at any time or
+not at all.  PDS being low may indicate that the card is still mating, and
+we could expect contact bounce to bring down the link as well.
+
+It is reasonable to assume that most cards will mate in a hotplug slot in
+about a second.  Thus, when we know PDS only reflects out-of-band presence
+detect, it's worthwhile to wait the extra second or so to make sure the
+card is properly mated before loading the driver and to prevent the hotplug
+code from disabling a device if the presence detect change goes active
+after the device is enabled.
+
+Link: https://lore.kernel.org/r/20191025190047.38130-3-stuart.w.hayes@gmail.com
+[bhelgaas: use ctrl_info() instead of pci_info()]
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Signed-off-by: Stuart Hayes <stuart.w.hayes@gmail.com>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Reviewed-by: Andy Shevchenko <andy.shevchenko@gmail.com>
+Reviewed-by: Lukas Wunner <lukas@wunner.de>
+(cherry picked from commit f496648b99f8f7f6711f7c30a6327381f37dd1e8)
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+No conflict
+---
+ drivers/pci/hotplug/pciehp_hpc.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/drivers/pci/hotplug/pciehp_hpc.c b/drivers/pci/hotplug/pciehp_hpc.c
+index c7e27d871de2d..8a6d4e8a343da 100644
+--- a/drivers/pci/hotplug/pciehp_hpc.c
++++ b/drivers/pci/hotplug/pciehp_hpc.c
+@@ -250,6 +250,22 @@ static bool pci_bus_check_dev(struct pci_bus *bus, int devfn)
+ 	return found;
+ }
+ 
++static void pcie_wait_for_presence(struct pci_dev *pdev)
++{
++	int timeout = 1250;
++	u16 slot_status;
++
++	do {
++		pcie_capability_read_word(pdev, PCI_EXP_SLTSTA, &slot_status);
++		if (slot_status & PCI_EXP_SLTSTA_PDS)
++			return;
++		msleep(10);
++		timeout -= 10;
++	} while (timeout > 0);
++
++	pci_info(pdev, "Timeout waiting for Presence Detect\n");
++}
++
+ int pciehp_check_link_status(struct controller *ctrl)
+ {
+ 	struct pci_dev *pdev = ctrl_dev(ctrl);
+@@ -268,6 +284,10 @@ int pciehp_check_link_status(struct controller *ctrl)
+ 
+ 	/* wait 100ms before read pci conf, and try in 1s */
+ 	msleep(100);
++
++	if (ctrl->inband_presence_disabled)
++		pcie_wait_for_presence(pdev);
++
+ 	found = pci_bus_check_dev(ctrl->pcie->port->subordinate,
+ 					PCI_DEVFN(0, 0));
+ 

--- a/SOURCES/0003-PCI-pciehp-Add-DMI-table-for-in-band-presence-detect.patch
+++ b/SOURCES/0003-PCI-pciehp-Add-DMI-table-for-in-band-presence-detect.patch
@@ -1,0 +1,76 @@
+From 9bb8844d7920769322c90d211688c7fef8aeb769 Mon Sep 17 00:00:00 2001
+From: Stuart Hayes <stuart.w.hayes@gmail.com>
+Date: Fri, 25 Oct 2019 15:00:47 -0400
+Subject: PCI: pciehp: Add DMI table for in-band presence detection disabled
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Some systems have in-band presence detection disabled for hot-plug PCI
+slots but do not report this in the slot capabilities 2 (SLTCAP2) register.
+On these systems, presence detect can become active well after the link is
+reported to be active, which can cause the slots to be disabled after a
+device is connected.
+
+Add a DMI table to flag these systems as having in-band presence detect
+disabled.
+
+Link: https://lore.kernel.org/r/20191025190047.38130-4-stuart.w.hayes@gmail.com
+Signed-off-by: Stuart Hayes <stuart.w.hayes@gmail.com>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Reviewed-by: Andy Shevchenko <andy.shevchenko@gmail.com>
+Reviewed-by: Lukas Wunner <lukas@wunner.de>
+(cherry picked from commit 0b382546d863f2f09eecaccda95a0b4bfd148f92)
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+No conflict
+---
+ drivers/pci/hotplug/pciehp_hpc.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/drivers/pci/hotplug/pciehp_hpc.c b/drivers/pci/hotplug/pciehp_hpc.c
+index 8a6d4e8a343da..f6333368e3eee 100644
+--- a/drivers/pci/hotplug/pciehp_hpc.c
++++ b/drivers/pci/hotplug/pciehp_hpc.c
+@@ -12,6 +12,7 @@
+  * Send feedback to <greg@kroah.com>,<kristen.c.accardi@intel.com>
+  */
+ 
++#include <linux/dmi.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/types.h>
+@@ -27,6 +28,24 @@
+ #include "../pci.h"
+ #include "pciehp.h"
+ 
++static const struct dmi_system_id inband_presence_disabled_dmi_table[] = {
++	/*
++	 * Match all Dell systems, as some Dell systems have inband
++	 * presence disabled on NVMe slots (but don't support the bit to
++	 * report it). Setting inband presence disabled should have no
++	 * negative effect, except on broken hotplug slots that never
++	 * assert presence detect--and those will still work, they will
++	 * just have a bit of extra delay before being probed.
++	 */
++	{
++		.ident = "Dell System",
++		.matches = {
++			DMI_MATCH(DMI_OEM_STRING, "Dell System"),
++		},
++	},
++	{}
++};
++
+ static inline struct pci_dev *ctrl_dev(struct controller *ctrl)
+ {
+ 	return ctrl->pcie->port;
+@@ -925,6 +944,9 @@ struct controller *pcie_init(struct pcie_device *dev)
+ 		ctrl->inband_presence_disabled = 1;
+ 	}
+ 
++	if (dmi_first_match(inband_presence_disabled_dmi_table))
++		ctrl->inband_presence_disabled = 1;
++
+ 	/* Check if Data Link Layer Link Active Reporting is implemented */
+ 	pcie_capability_read_dword(pdev, PCI_EXP_LNKCAP, &link_cap);
+ 	if (link_cap & PCI_EXP_LNKCAP_DLLLARC)

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.6%{?dist}
+Release: %{?xsrel}.7%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -751,6 +751,14 @@ Patch1014: 0006-net-rds-reset-op_nents-when-zerocopy-page-pin-fails.patch
 # CVE-2026-46243 (cifswitch)
 Patch1015: 0007-smb-client-reject-userspace-cifs-spnego-descriptions.patch
 
+# Backport fixes in pcieport driver for hotplug hardware detection
+Patch1020: 0001-PCI-pciehp-Differentiate-between-surprise-and-safe-r.patch
+Patch1021: 0002-PCI-pciehp-Tolerate-Presence-Detect-hardwired-to-zer.patch
+# The following patches fix a regression introduced by the previous patches
+Patch1022: 0001-PCI-pciehp-Disable-in-band-presence-detect-when-poss.patch
+Patch1023: 0002-PCI-pciehp-Wait-for-PDS-if-in-band-presence-is-disab.patch
+Patch1024: 0003-PCI-pciehp-Add-DMI-table-for-in-band-presence-detect.patch
+
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
 Linux operating system. The kernel handles the basic functions of the operating
@@ -1104,6 +1112,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Thu Jul 02 2026 Thierry Escande <thierry.escande@vates.tech> - 4.19.19-8.0.46.7
+- Backport fixes in pcieport driver for hotplug hardware detection
+
 * Wed Jun 03 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 4.19.19-8.0.46.6
 - Backport for CVE-2026-46243 (cifswitch)
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3496

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

On probe, pciehp assumes an empty slot if Presence Detect State is zero, regardless of Link Active being one. The subsequent Link Up event doesn't result in the device being reattached, leaving the slot empty until something re-triggers enumeration.

This behavior has been observed an AMD EPYC system where SSDs plugged to a hotplug capable PCI bridge were not seen at boot time but only after a manual rescan of the PCI bus with 'echo 1 > /sys/bus/pci/rescan'.

The 2 first patches fix broken hardware and assume the slot is occupied if Link Active is set. The 2nd patch is part of a [bigger patchset](https://lore.kernel.org/linux-pci/cover.1536341821.git.lukas@wunner.de/) that we didn't backport as it is mostly cleanup in the hotplug driver and breaks the kernel ABI.

Following [this bug report](https://lore.kernel.org/linux-pci/1579083986.15925.31.camel@suse.com/), the 3 remaining patches fix a regression introduced by the previous patches where presence detection could be disabled for some systems. The patchset is available [here](https://lore.kernel.org/linux-pci/20191025190047.38130-1-stuart.w.hayes@gmail.com/).

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next+1

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

On some systems, PCIe expansion cards connected to a hotplug capable PCI bus might not be seen at boot time. This release fixes such systems.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

As a bug fix for an issue only seen on the hardware of a possible partner I don't think there is need to update the documentation.

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Installed and booted on the partner hardware. Also asked him for further testing (hw unplug/re-plug, fs creation): Everything works as expected.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Hard to tell as this would need access to hardware to physically test PCI device hotplug. As said above, the only regression test done so far was on the partner hardware where they tested this new kernel by removing/adding disk drives (where it worked flawlessly).

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Host boot only. See bellow for possible new tests.

#### What tests have been or will be added to CI for this change? If none, explain why.

~~Quentin is working on a PCI device hotplug test for our test suite (no PR as of now).~~
As explained by Quentin, testing the code paths touched by this modifications does not work when trying to unplug/replug devices on a XCP-ng VM. But the changes are relatively low risks and generic code path should be exercised by our standard tests.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
