### PR TITLE
Fix for CVE-2026-64600 RefluXFS

### DIFF
--- a/SOURCES/0001-xfs-resample-the-data-fork-mapping-after-cycling-ILO.patch
+++ b/SOURCES/0001-xfs-resample-the-data-fork-mapping-after-cycling-ILO.patch
@@ -1,0 +1,82 @@
+From 57e36a88e7dd9ac86f80de25dd6e22848fc7cd9c Mon Sep 17 00:00:00 2001
+From: "Darrick J. Wong" <djwong@kernel.org>
+Date: Mon, 13 Jul 2026 23:03:44 -0700
+Subject: [PATCH] xfs: resample the data fork mapping after cycling ILOCK
+
+commit 2f4acd0fcd862e22eab45690ec2c08c80b6ef2e7 upstream.
+
+xfs_reflink_fill_{cow_hole,delalloc} are both presented with an inode,
+a data fork mapping, and a cow fork mapping.  Unfortunately, these two
+helpers cycle the ILOCK to grab a transaction, which means that the
+mappings are stale as soon as we reacquire the ILOCK.  Currently we
+refresh the cow fork mapping by re-calling xfs_find_trim_cow_extent, but
+we don't refresh the data fork mapping beforehand, which means that the
+xfs_bmap_trim_cow in that function queries the refcount btree about the
+wrong physical blocks and returns an inaccurate value in *shared.
+
+If *shared is now false, the directio write proceeds with a stale data
+fork mapping.  Fix this by querying the data fork mapping if the
+sequence counter changes across the ILOCK cycle.
+
+Cc: hch@lst.de
+Cc: stable@vger.kernel.org # v4.11
+Fixes: 3c68d44a2b49a0 ("xfs: allocate direct I/O COW blocks in iomap_begin")
+Signed-off-by: "Darrick J. Wong" <djwong@kernel.org>
+Reviewed-by: Christoph Hellwig <hch@lst.de>
+Reviewed-by: Carlos Maiolino <cmaiolino@redhat.com>
+Signed-off-by: Carlos Maiolino <cem@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit e705d81a7193dd19e69b8e2bad4696d78a4ea075)
+
+Backports to v4.19, conflicts due to missing:
+
+- f273387b0485 ("xfs: refactor reflink functions to use
+xfs_trans_alloc_inode"): slight context differences with use of
+xfs_trans_alloc_inode instead of open-coding the locking
+
+- d62113303d69 ("xfs: Fix false ENOSPC when performing direct write on a
+delalloc extent in cow fork"), function split into two helpers to prevent
+enospace conditions with delalloc -> we only need to add one hunk in the
+non-split xfs_reflink_allocate_cow function.
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ fs/xfs/xfs_reflink.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/fs/xfs/xfs_reflink.c b/fs/xfs/xfs_reflink.c
+index 42ea7bab9144..e3160ce7a8c8 100644
+--- a/fs/xfs/xfs_reflink.c
++++ b/fs/xfs/xfs_reflink.c
+@@ -405,6 +405,7 @@ xfs_reflink_allocate_cow(
+ 	xfs_fileoff_t		offset_fsb = imap->br_startoff;
+ 	xfs_filblks_t		count_fsb = imap->br_blockcount;
+ 	struct xfs_trans	*tp;
++	unsigned int            seq_before = READ_ONCE(ip->i_df.if_seq);
+ 	int			nimaps, error = 0;
+ 	bool			found;
+ 	xfs_filblks_t		resaligned;
+@@ -435,6 +436,23 @@ xfs_reflink_allocate_cow(
+ 	if (error)
+ 		goto out_trans_cancel;
+ 
++	/*
++	 * The data fork mapping may have changed while we dropped the ILOCK
++	 * (a racing O_DIRECT writer under IOLOCK_SHARED can complete a full
++	 * CoW cycle including xfs_reflink_end_cow(), which remaps this offset
++	 * and drops the refcount of the old shared block).  Re-read it so the
++	 * shared-status recheck below and the caller's in-place iomap both
++	 * operate on the current mapping rather than a stale physical block.
++	 */
++	if (seq_before != READ_ONCE(ip->i_df.if_seq)) {
++		nimaps = 1;
++		error = xfs_bmapi_read(ip, imap->br_startoff,
++				       imap->br_blockcount, imap, &nimaps, 0);
++		if (error)
++			goto out_trans_cancel;
++	}
++
++
+ 	/*
+ 	 * Check for an overlapping extent again now that we dropped the ilock.
+ 	 */

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.9%{?dist}
+Release: %{?xsrel}.10%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -764,6 +764,9 @@ Patch1025: 0656-openvswitch-cap-upcall-PID-array-size-and-pre-size-v.patch
 # CVE-2026-53227 (net: openvswitch: fix possible kfree_skb of ERR_PTR)
 Patch1026: 0657-net-openvswitch-fix-possible-kfree_skb-of-ERR_PTR.patch
 
+# CVE-2026-64600 (RefluXFS)
+Patch1027: 0001-xfs-resample-the-data-fork-mapping-after-cycling-ILO.patch
+
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
 Linux operating system. The kernel handles the basic functions of the operating
@@ -1117,6 +1120,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Thu Aug 06 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.19.19-8.0.46.10
+- Backport for CVE-2026-64600 (RefluXFS)
+
 * Tue Aug 04 2026 Philippe Coval <philippe.coval@vates.tech> - 4.19.19-8.0.46.9
 - Rebuild against OpenSSL 3.0
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3655

#### Related changes (optional)

N/A

#### Context & Motivation

A local privileged escalation discovered by Qualys using AI assisted vulnerability scanning, was made public on oss-sec: https://www.openwall.com/lists/oss-security/2026/07/22/14.  The vulnerability is present in the XFS filesystem.

ANSWER

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

Release with the next batch of updates as this is a security fix.
---

### Release Notes and Documentation

#### Explain the change to users

A race condition in the XFS filesystem when reflinking support is enabled allows a local unprivileged user to write to files they have otherwise no write access to.  This could allow an unprivileged user to elevate its previleges to the root account by, for example, tampering with /etc/passwd.  Changes made to files using this vulnerability are persisted on-disk and survive a host reboot.

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

EXPLANATIONS

N/A.

---

### Testing and regression avoidance

#### What tests have you performed?

Run xfstests on a VM with the fix and did not notice any particular regression.  No public exploit published yet to verify the backported fix.

#### What manual tests should be performed after the build, and by whom?

None

#### What's covered by the xcp-ng-tests test suite?

Tests in `tests/storage/xfs` should exercize the XFS code, although no particular test seems to rely on/exercize the reflinking feature.

#### What tests have been or will be added to CI for this change? If none, explain why.

None.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
