### PR TITLE
Backports OpenvSwitch fixes for CVE-2026-45840 and CVE-2026-53227

### DIFF
--- a/SOURCES/0656-openvswitch-cap-upcall-PID-array-size-and-pre-size-v.patch
+++ b/SOURCES/0656-openvswitch-cap-upcall-PID-array-size-and-pre-size-v.patch
@@ -1,0 +1,130 @@
+From 5ca40e28fed8930d7bd305fe1331cd513e13abda Mon Sep 17 00:00:00 2001
+From: Weiming Shi <bestswngs@gmail.com>
+Date: Wed, 15 Apr 2026 19:46:54 -0700
+Subject: [PATCH] openvswitch: cap upcall PID array size and pre-size vport
+ replies
+
+[ Upstream commit 2091c6aa0df6aba47deb5c8ab232b1cb60af3519 ]
+
+The vport netlink reply helpers allocate a fixed-size skb with
+nlmsg_new(NLMSG_DEFAULT_SIZE, ...) but serialize the full upcall PID
+array via ovs_vport_get_upcall_portids().  Since
+ovs_vport_set_upcall_portids() accepts any non-zero multiple of
+sizeof(u32) with no upper bound, a CAP_NET_ADMIN user can install a PID
+array large enough to overflow the reply buffer, causing nla_put() to
+fail with -EMSGSIZE and hitting BUG_ON(err < 0).  On systems with
+unprivileged user namespaces enabled (e.g., Ubuntu default), this is
+reachable via unshare -Urn since OVS vport mutation operations use
+GENL_UNS_ADMIN_PERM.
+
+ kernel BUG at net/openvswitch/datapath.c:2414!
+ Oops: invalid opcode: 0000 [#1] SMP KASAN NOPTI
+ CPU: 1 UID: 0 PID: 65 Comm: poc Not tainted 7.0.0-rc7-00195-geb216e422044 #1
+ RIP: 0010:ovs_vport_cmd_set+0x34c/0x400
+ Call Trace:
+  <TASK>
+  genl_family_rcv_msg_doit (net/netlink/genetlink.c:1116)
+  genl_rcv_msg (net/netlink/genetlink.c:1194)
+  netlink_rcv_skb (net/netlink/af_netlink.c:2550)
+  genl_rcv (net/netlink/genetlink.c:1219)
+  netlink_unicast (net/netlink/af_netlink.c:1344)
+  netlink_sendmsg (net/netlink/af_netlink.c:1894)
+  __sys_sendto (net/socket.c:2206)
+  __x64_sys_sendto (net/socket.c:2209)
+  do_syscall_64 (arch/x86/entry/syscall_64.c:63)
+  entry_SYSCALL_64_after_hwframe (arch/x86/entry/entry_64.S:130)
+  </TASK>
+ Kernel panic - not syncing: Fatal exception
+
+Reject attempts to set more PIDs than nr_cpu_ids in
+ovs_vport_set_upcall_portids(), and pre-compute the worst-case reply
+size in ovs_vport_cmd_msg_size() based on that bound, similar to the
+existing ovs_dp_cmd_msg_size().  nr_cpu_ids matches the cap already
+used by the per-CPU dispatch configuration on the datapath side
+(ovs_dp_cmd_fill_info() serialises at most nr_cpu_ids PIDs), so the
+two sides stay consistent.
+
+Fixes: 5cd667b0a456 ("openvswitch: Allow each vport to have an array of 'port_id's.")
+Reported-by: Xiang Mei <xmei5@asu.edu>
+Assisted-by: Claude:claude-opus-4-6
+Signed-off-by: Weiming Shi <bestswngs@gmail.com>
+Reviewed-by: Ilya Maximets <i.maximets@ovn.org>
+Link: https://patch.msgid.link/20260416024653.153456-2-bestswngs@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+(cherry picked from commit 8d59b80e69dddb665eb2de36e62859ab2073470e)
+Signed-off-by: Sebastien Rodot <sebastien.rodot@vates.tech>
+---
+ net/openvswitch/datapath.c | 35 +++++++++++++++++++++++++++++++++--
+ net/openvswitch/vport.c    |  3 +++
+ 2 files changed, 36 insertions(+), 2 deletions(-)
+
+diff --git a/net/openvswitch/datapath.c b/net/openvswitch/datapath.c
+index 8e396c7c8389..de7414c5abf1 100644
+--- a/net/openvswitch/datapath.c
++++ b/net/openvswitch/datapath.c
+@@ -1893,9 +1893,40 @@ static int ovs_vport_cmd_fill_info(struct vport *vport, struct sk_buff *skb,
+ 	return err;
+ }
+ 
++static size_t ovs_vport_cmd_msg_size(void)
++{
++	size_t msgsize = NLMSG_ALIGN(sizeof(struct ovs_header));
++
++	msgsize += nla_total_size(sizeof(u32)); /* OVS_VPORT_ATTR_PORT_NO */
++	msgsize += nla_total_size(sizeof(u32)); /* OVS_VPORT_ATTR_TYPE */
++	msgsize += nla_total_size(IFNAMSIZ);    /* OVS_VPORT_ATTR_NAME */
++	msgsize += nla_total_size(sizeof(u32)); /* OVS_VPORT_ATTR_IFINDEX */
++	msgsize += nla_total_size(sizeof(s32)); /* OVS_VPORT_ATTR_NETNSID */
++
++	/* OVS_VPORT_ATTR_STATS */
++	msgsize += nla_total_size_64bit(sizeof(struct ovs_vport_stats));
++
++	/* OVS_VPORT_ATTR_UPCALL_STATS(OVS_VPORT_UPCALL_ATTR_SUCCESS +
++	 *                             OVS_VPORT_UPCALL_ATTR_FAIL)
++	 */
++	msgsize += nla_total_size(nla_total_size_64bit(sizeof(u64)) +
++				  nla_total_size_64bit(sizeof(u64)));
++
++	/* OVS_VPORT_ATTR_UPCALL_PID */
++	msgsize += nla_total_size(nr_cpu_ids * sizeof(u32));
++
++	/* OVS_VPORT_ATTR_OPTIONS(OVS_TUNNEL_ATTR_DST_PORT +
++	 *                        OVS_TUNNEL_ATTR_EXTENSION(OVS_VXLAN_EXT_GBP))
++	 */
++	msgsize += nla_total_size(nla_total_size(sizeof(u16)) +
++				  nla_total_size(nla_total_size(0)));
++
++	return msgsize;
++}
++
+ static struct sk_buff *ovs_vport_cmd_alloc_info(void)
+ {
+-	return nlmsg_new(NLMSG_DEFAULT_SIZE, GFP_KERNEL);
++	return genlmsg_new(ovs_vport_cmd_msg_size(), GFP_KERNEL);
+ }
+ 
+ /* Called with ovs_mutex, only via ovs_dp_notify_wq(). */
+@@ -1905,7 +1936,7 @@ struct sk_buff *ovs_vport_cmd_build_info(struct vport *vport, struct net *net,
+ 	struct sk_buff *skb;
+ 	int retval;
+ 
+-	skb = nlmsg_new(NLMSG_DEFAULT_SIZE, GFP_ATOMIC);
++	skb = ovs_vport_cmd_alloc_info();
+ 	if (!skb)
+ 		return ERR_PTR(-ENOMEM);
+ 
+diff --git a/net/openvswitch/vport.c b/net/openvswitch/vport.c
+index 19f6765566e7..5541f4c9a0a1 100644
+--- a/net/openvswitch/vport.c
++++ b/net/openvswitch/vport.c
+@@ -353,6 +353,9 @@ int ovs_vport_set_upcall_portids(struct vport *vport, const struct nlattr *ids)
+ 	if (!nla_len(ids) || nla_len(ids) % sizeof(u32))
+ 		return -EINVAL;
+ 
++	if (nla_len(ids) / sizeof(u32) > nr_cpu_ids)
++		return -EINVAL;
++
+ 	old = ovsl_dereference(vport->upcall_portids);
+ 
+ 	vport_portids = kmalloc(sizeof(*vport_portids) + nla_len(ids),

--- a/SOURCES/0657-net-openvswitch-fix-possible-kfree_skb-of-ERR_PTR.patch
+++ b/SOURCES/0657-net-openvswitch-fix-possible-kfree_skb-of-ERR_PTR.patch
@@ -1,0 +1,44 @@
+From 8e8816a8b0fa6ec9e13840a45417fa8f6e81e98f Mon Sep 17 00:00:00 2001
+From: Adrian Moreno <amorenoz@redhat.com>
+Date: Thu, 4 Jun 2026 14:19:46 +0200
+Subject: [PATCH] net: openvswitch: fix possible kfree_skb of ERR_PTR
+
+[ Upstream commit ee30dd2909d8b98619f4341c70ec8dc8e155ab02 ]
+
+After the patch in the "Fixes" tag, the allocation of the "reply" skb
+can happen either before or after locking the ovs_mutex.
+
+However, error cleanups still follow the classical reversed order,
+assuming "reply" is allocated before locking: it is freed after unlocking.
+
+If "reply" allocation happens after locking the mutex and it fails,
+"reply" is left with an ERR_PTR, and execution jumps to the correspondent
+cleanup stage which will try to free an invalid pointer.
+
+Fix this by setting the pointer to NULL after having saved its error
+value.
+
+Fixes: 893f139b9a6c ("openvswitch: Minimize ovs_flow_cmd_new|set critical sections.")
+Signed-off-by: Adrian Moreno <amorenoz@redhat.com>
+Reviewed-by: Aaron Conole <aconole@redhat.com>
+Acked-by: Eelco Chaudron <echaudro@redhat.com>
+Link: https://patch.msgid.link/20260604121946.942164-1-amorenoz@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+(cherry picked from commit e248fb2e680deb2bd37bac551b72638fe4938a76)
+---
+ net/openvswitch/datapath.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/net/openvswitch/datapath.c b/net/openvswitch/datapath.c
+index de7414c5abf1..dfc7e2f45658 100644
+--- a/net/openvswitch/datapath.c
++++ b/net/openvswitch/datapath.c
+@@ -1194,6 +1194,7 @@ static int ovs_flow_cmd_set(struct sk_buff *skb, struct genl_info *info)
+ 
+ 		if (IS_ERR(reply)) {
+ 			error = PTR_ERR(reply);
++			reply = NULL;
+ 			goto err_unlock_ovs;
+ 		}
+ 	}

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.7%{?dist}
+Release: %{?xsrel}.8%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -759,6 +759,11 @@ Patch1022: 0001-PCI-pciehp-Disable-in-band-presence-detect-when-poss.patch
 Patch1023: 0002-PCI-pciehp-Wait-for-PDS-if-in-band-presence-is-disab.patch
 Patch1024: 0003-PCI-pciehp-Add-DMI-table-for-in-band-presence-detect.patch
 
+# CVE-2026-45840 (openvswitch: cap upcall PID array size and pre-size vport replies)
+Patch1025: 0656-openvswitch-cap-upcall-PID-array-size-and-pre-size-v.patch
+# CVE-2026-53227 (net: openvswitch: fix possible kfree_skb of ERR_PTR)
+Patch1026: 0657-net-openvswitch-fix-possible-kfree_skb-of-ERR_PTR.patch
+
 %description
 The kernel package contains the Linux kernel (vmlinuz), the core of any
 Linux operating system. The kernel handles the basic functions of the operating
@@ -1112,6 +1117,10 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Fri Jul 24 2026 Sebastien Rodot <sebastien.rodot@vates.tech> - 4.19.19-8.0.46.8
+- Backport fixes for CVE-2026-45840 (openvswitch: cap upcall PID array size and pre-size vport replies)
+- Backport fixes for CVE-2026-53227 (net: openvswitch: fix possible kfree_skb of ERR_PTR)
+
 * Thu Jul 02 2026 Thierry Escande <thierry.escande@vates.tech> - 4.19.19-8.0.46.7
 - Backport fixes in pcieport driver for hotplug hardware detection
 


### PR DESCRIPTION
koji test-build (on .7): https://koji.xcp-ng.org/buildinfo?buildID=5978 (pre-build on .8 [failed](https://koji.xcp-ng.org/taskinfo?taskID=109560))

### Main information

#### Work Item Reference

- SECUR-87 (covering SECUR-88 and SECUR-89)
- XCPNG-3597

#### Context & Motivation

- CVE-2026-53227 net: openvswitch: fix possible kfree_skb of ERR_PTR
- CVE-2026-45840 - openvswitch: cap upcall PID array size and pre-size vport replies

both are low impact CVEs, reachable from dom0, and leading to DoS.

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [X] I'm not sure, let's talk about it.

---

### Release Notes and Documentation

#### Explain the change to users

Reliability fixes for CVE-2026-45840 and CVE-2026-53227.

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

#### What tests have you performed?

Running `xcp-ng-tests` (`tests/misc` + few others)

#### What manual tests should be performed after the build, and by whom?

N/A

#### What's covered by the xcp-ng-tests test suite?

CI is ensuring OVS subsystem is still working (basic operations using ssh are still working fine, and intra and inter pool communication is still fine).

#### What tests have been or will be added to CI for this change? If none, explain why.

None, as it is reliability fixes. Additionally, specifically exercising these codepaths could be really tricky.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
