### PR TITLE
XCPNG-3597: Rebuild against OpenSSL 3.0

### DIFF
--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -42,7 +42,7 @@
 Name: kernel
 License: GPLv2
 Version: 4.19.19
-Release: %{?xsrel}.8%{?dist}
+Release: %{?xsrel}.9%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -1117,6 +1117,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue Aug 04 2026 Philippe Coval <philippe.coval@vates.tech> - 4.19.19-8.0.46.9
+- Rebuild against OpenSSL 3.0
+
 * Fri Jul 24 2026 Sebastien Rodot <sebastien.rodot@vates.tech> - 4.19.19-8.0.46.8
 - Backport fixes for CVE-2026-45840 (openvswitch: cap upcall PID array size and pre-size vport replies)
 - Backport fixes for CVE-2026-53227 (net: openvswitch: fix possible kfree_skb of ERR_PTR)


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3597

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

Related-to: https://github.com/xcp-ng-rpms/kernel/pull/37 ( XCPNG-3597)
Related-to: https://github.com/xcp-ng-rpms/openssl/pull/8 ( XCPNG-3273  )


#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

OpenSSL 3.5 was updated but it has to be reverted (it was breaking OpenSSH rebuild)


#### Release Target

- [x] milestone defined :  next

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->



---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Not needed (rely on previous change)

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

none: maybe openssh will be fixed later tbc

#### Documentation update needed

- [x] No


---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Refer to info in related PR

none relying on ci

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Refer to info in related PR

none relying on ci

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Refer to info in related PR

none relying on ci

#### What tests have been or will be added to CI for this change? If none, explain why.

Refer to info in related PR

none relying on ci

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
