### PR TITLE
Fixes for non-SB boot and upgrade from old proto

### DIFF
--- a/SOURCES/kernel-x86_64.config
+++ b/SOURCES/kernel-x86_64.config
@@ -892,9 +892,7 @@ CONFIG_MODVERSIONS=y
 CONFIG_ASM_MODVERSIONS=y
 CONFIG_MODULE_SRCVERSION_ALL=y
 CONFIG_MODULE_SIG=y
-CONFIG_MODULE_SIG_FORCE=y
 # CONFIG_MODULE_SIG_ALL is not set
-
 #
 # Do not forget to sign required modules with scripts/sign-file
 #

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -472,7 +472,7 @@ fi
 
 %changelog
 
-* Wed Apr 29 2026 Corentin Oparowski <corentin.oparowski@vates.tech> - 6.12.0-1.0
+* Wed Apr 29 2026 Corentin Oparowski <corentin.oparowski@vates.tech> - 6.12.0-1
 - update filter-hypercall.patch to match XS lastest version
 - update to XS9 .config
 - Switch to UEK8 with XS9 rebased patches

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -34,7 +34,7 @@
 Name: kernel
 License: GPLv2
 Version: %{usver}
-Release: 1%{dist}
+Release: 2%{dist}
 ExclusiveOS: Linux
 Summary: The Linux kernel
 BuildRequires: kmod
@@ -80,6 +80,7 @@ AutoReqProv: no
 Provides: kernel-uname-r = %{uname}
 Provides: kernel = %{version}-%{release}
 Provides: kernel-%{_arch} = %{version}-%{release}
+Provides: kernel-xcpng
 Requires(post): coreutils kmod
 Requires(posttrans): coreutils dracut kmod
 
@@ -471,6 +472,8 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Fri Aug 07 2026 Yann Dirson <yann.dirson@vates.tech> - 6.12.0-2
+- Add "Provides: kernel-xcpng" so the installer can be sure to pull this kernel not Alma's
 
 * Wed Apr 29 2026 Corentin Oparowski <corentin.oparowski@vates.tech> - 6.12.0-1
 - update filter-hypercall.patch to match XS lastest version

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -114,7 +114,7 @@ Patch19: 0019-The-objective-is-to-ensure-we-have-a-large-enough-co.patch
 Patch20: 0020-Revert-to-use-num_online_cpus-for-default-rss-queues.patch
 Patch21: 0021-Add-SBAT-metadata-to-dom0-6.6-kernel.patch
 Patch22: 0022-Enable-lockdown-integrity-by-default.patch
-Patch23: 0023-For-XenServer-the-desired-behaviour-is-that-signatur.patch
+#Patch23: 0023-For-XenServer-the-desired-behaviour-is-that-signatur.patch
 Patch24: 0024-Use-MoK-variable-fallback.patch
 Patch25: 0025-Allows-Xen-Netback-debug-ring-files-to-be-read-if-lo.patch
 Patch26: 0026-Import-the-Xen-public-headers-in-preparation-for-fil.patch
@@ -474,6 +474,8 @@ fi
 %changelog
 * Fri Aug 07 2026 Yann Dirson <yann.dirson@vates.tech> - 6.12.0-2
 - Add "Provides: kernel-xcpng" so the installer can be sure to pull this kernel not Alma's
+- Disable XS modification of CONFIG_MODULE_SIG_FORCE behaviour
+- Disable CONFIG_MODULE_SIG_FORCE in config
 
 * Wed Apr 29 2026 Corentin Oparowski <corentin.oparowski@vates.tech> - 6.12.0-1
 - update filter-hypercall.patch to match XS lastest version


### PR DESCRIPTION
This includes the config fixes previously discussed with H&K team, and introduces `Provides: kernel-xcpng` to prevent ever upgrading to an Alma kernel by mistake.